### PR TITLE
fix doc of cluster_table.date.md  Name mistake

### DIFF
--- a/docs/zh_cn/configuration/cluster_conf/cluster_table.data.md
+++ b/docs/zh_cn/configuration/cluster_conf/cluster_table.data.md
@@ -23,7 +23,7 @@ cluster_table.data配置文件记录各后端集群包含的子集群及实例
 | Addr    | String<br>实例监听地址 |
 | Port    | Integer<br>实例监听端口 |
 | Weight  | Integer<br>实例权重 |
-| Addr    | String<br>实例名称 |
+| Name    | String<br>实例名称 |
 
 
 ## 配置示例


### PR DESCRIPTION
修改文档：实例负载均衡配置  中的拼写错误，确认仅中文版有误，英文版正确