### PR TITLE
fix issue #629

### DIFF
--- a/bfe_server/reverseproxy.go
+++ b/bfe_server/reverseproxy.go
@@ -727,7 +727,7 @@ func (p *ReverseProxy) ServeHTTP(rw bfe_http.ResponseWriter, basicReq *bfe_basic
 	// to objects which are not used any more.
 	basicReq.SvrDataConf = nil
 
-	if err != nil {
+	if err != nil || res == nil {
 		basicReq.Stat.ResponseStart = time.Now()
 		basicReq.BfeStatusCode = bfe_http.StatusInternalServerError
 		res = bfe_basic.CreateInternalSrvErrResp(basicReq)


### PR DESCRIPTION
Signed-off-by: xiaoyuqi <xiaoyuqi@baidu.com>
## Bug Fix
If module return close in `handleForward` phase, BFE will panic cause of closing body of nil response. Detail see: [issue629](https://github.com/bfenetworks/bfe/issues/629)