### PR TITLE
optimize ws, add real client ip to http header when ws handshake

### DIFF
--- a/bfe_basic/common.go
+++ b/bfe_basic/common.go
@@ -20,6 +20,9 @@ import (
 )
 
 const (
+	HeaderClientIP      = "CLIENTIP"
+	HeaderClientIP6     = "Clientip6"
+	HeaderClientPort    = "CLIENTPORT"
 	HeaderBfeIP         = "X-Bfe-Ip"
 	HeaderBfeLogId      = "X-Bfe-Log-Id"
 	HeaderForwardedHost = "X-Forwarded-Host"

--- a/bfe_websocket/server_tester.go
+++ b/bfe_websocket/server_tester.go
@@ -103,6 +103,8 @@ func (st *ServerTester) handleWebsocketConn(conn net.Conn) {
 		return
 	}
 
+	req.State.Conn = conn
+
 	// create ResponseWriter
 	rw := NewMockResponseWriter(conn, wr)
 


### PR DESCRIPTION
Signed-off-by: xiaoyuqi <xiaoyuqi@baidu.com>
In websocket situation, BFE do not send real client ip to backend. To fix this issue, we add real client ip to http header in ws handshake stage.