### PR TITLE
sync net/textproto cp 93af67783796a48b3f59bd969dc0c528c37571ec proper…

### DIFF
--- a/bfe_net/textproto/writer.go
+++ b/bfe_net/textproto/writer.go
@@ -75,7 +75,8 @@ type dotWriter struct {
 }
 
 const (
-	wstateBeginLine = iota // beginning of line; initial state; must be zero
+	wstateBegin     = iota // initial state; must be zero
+	wstateBeginLine        // beginning of line
 	wstateCR               // wrote \r (possibly at end of line)
 	wstateData             // writing data in middle of line
 )
@@ -85,7 +86,7 @@ func (d *dotWriter) Write(b []byte) (n int, err error) {
 	for n < len(b) {
 		c := b[n]
 		switch d.state {
-		case wstateBeginLine:
+		case wstateBegin, wstateBeginLine:
 			d.state = wstateData
 			if c == '.' {
 				// escape leading dot

--- a/bfe_net/textproto/writer_test.go
+++ b/bfe_net/textproto/writer_test.go
@@ -50,3 +50,29 @@ func TestDotWriter(t *testing.T) {
 		t.Fatalf("wrote %q", s)
 	}
 }
+
+func TestDotWriterCloseEmptyWrite(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(bfe_bufio.NewWriter(&buf))
+	d := w.DotWriter()
+	n, err := d.Write([]byte{})
+	if n != 0 || err != nil {
+		t.Fatalf("Write: %d, %s", n, err)
+	}
+	d.Close()
+	want := "\r\n.\r\n"
+	if s := buf.String(); s != want {
+		t.Fatalf("wrote %q; want %q", s, want)
+	}
+}
+
+func TestDotWriterCloseNoWrite(t *testing.T) {
+	var buf bytes.Buffer
+	w := NewWriter(bfe_bufio.NewWriter(&buf))
+	d := w.DotWriter()
+	d.Close()
+	want := "\r\n.\r\n"
+	if s := buf.String(); s != want {
+		t.Fatalf("wrote %q; want %q", s, want)
+	}
+}


### PR DESCRIPTION
…ly write terminating sequence if DotWriter is cl…

detail see: https://github.com/golang/go/commit/93af67783796a48b3f59bd969dc0c528c37571ec

Signed-off-by: xiaoyuqi <xiaoyuqi@baidu.com>