### PR TITLE
sync net/textproto reader trim line

### DIFF
--- a/bfe_net/textproto/reader.go
+++ b/bfe_net/textproto/reader.go
@@ -169,7 +169,7 @@ func (r *Reader) readContinuedLineSlice() ([]byte, error) {
 			break
 		}
 		r.buf = append(r.buf, ' ')
-		r.buf = append(r.buf, line...)
+		r.buf = append(r.buf, trim(line)...)
 	}
 	return r.buf, nil
 }

--- a/bfe_net/textproto/reader_test.go
+++ b/bfe_net/textproto/reader_test.go
@@ -191,6 +191,32 @@ func TestReadMIMEHeaderNonCompliant(t *testing.T) {
 	}
 }
 
+// Test that continued lines are properly trimmed. Issue 11204.
+func TestReadMIMEHeaderTrimContinued(t *testing.T) {
+	// In this header, \n and \r\n terminated lines are mixed on purpose.
+	// We expect each line to be trimmed (prefix and suffix) before being concatenated.
+	// Keep the spaces as they are.
+	r := reader("" + // for code formatting purpose.
+		"a:\n" +
+		" 0 \r\n" +
+		"b:1 \t\r\n" +
+		"c: 2\r\n" +
+		" 3\t\n" +
+		"  \t 4  \r\n\n")
+	m, err := r.ReadMIMEHeader()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := MIMEHeader{
+		"A": {"0"},
+		"B": {"1"},
+		"C": {"2 3 4"},
+	}
+	if !reflect.DeepEqual(m, want) {
+		t.Fatalf("ReadMIMEHeader mismatch.\n got: %q\nwant: %q", m, want)
+	}
+}
+
 type readResponseTest struct {
 	in       string
 	inCode   int


### PR DESCRIPTION
Signed-off-by: xiaoyuqi <xiaoyuqi@baidu.com>

sycn golang/go net/textproto, [commit](https://github.com/golang/go/commit/6f772787f97720aeeb98d37b2c63b1a3155588d1)