### PR TITLE
sync http2, discard DATA frames with higher stream IDs after shutdown #450

### DIFF
--- a/bfe_http2/server_test.go
+++ b/bfe_http2/server_test.go
@@ -2960,3 +2960,48 @@ y2ptGsuSmgUtWj3NM9xuwYPm+Z/F84K6+ARYiZ6PYj013sovGKUFfYAqVXVlxtIX
 qyUBnu3X9ps8ZfjLZO7BAkEAlT4R5Yl6cGhaJQYZHOde3JEMhNRcVFMO8dJDaFeo
 f9Oeos0UUothgiDktdQHxdNEwLjQf7lJJBzV+5OtwswCWA==
 -----END RSA PRIVATE KEY-----`)
+
+func TestNoRstPostAfterGOAWAY(t *testing.T) {
+	const msg = "Hello, world."
+	st := newServerTester(t, func(w http.ResponseWriter, r *http.Request) {
+		n, err := io.Copy(ioutil.Discard, r.Body)
+		if err != nil || n > 0 {
+			t.Errorf("Read %d bytes, error %v; want 0 bytes.", n, err)
+		}
+		io.WriteString(w, msg)
+	})
+	defer st.Close()
+	st.greet()
+	// Give the server quota to reply. (plus it has the the 64KB)
+	if err := st.fr.WriteWindowUpdate(0, uint32(1*len(msg))); err != nil {
+		t.Fatal(err)
+	}
+	hbf := st.encodeHeader(":method", "POST")
+	st.writeHeaders(HeadersFrameParam{
+		StreamID:      1,
+		BlockFragment: hbf,
+		EndStream:     false,
+		EndHeaders:    true,
+	})
+	close(st.sc.closeNotifyCh)
+	st.writeData(1, true, nil)
+
+	st.wantGoAway()
+	for {
+		f, err := st.readFrame()
+		if err == io.EOF {
+			st.t.Fatal("got a EOF; want *GoAwayFrame")
+		}
+		if err != nil && err.Error() == "timeout waiting for frame" {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		if gf, ok := f.(*RSTStreamFrame); ok && gf.StreamID == 1 {
+			t.Fatal("got rst but want no ret")
+			break
+		}
+	}
+
+}


### PR DESCRIPTION
Signed-off-by: xiaoyuqi <xiaoyuqi@baidu.com>
sync from golang/net http2 [commit](https://github.com/golang/net/commit/39120d07d75e76f0079fe5d27480bcb965a21e4c)

currently bfe will send rst if the server receives data after goway. 
As describe in https://tools.ietf.org/html/rfc7540#section-6.8, BFE should do nothing when receives data after goway.