### PR TITLE
sync http2, receiving too much data is a protocol error

### DIFF
--- a/bfe_http2/server.go
+++ b/bfe_http2/server.go
@@ -1618,7 +1618,10 @@ func (sc *serverConn) processData(f *DataFrame) error {
 	if st.declBodyBytes != -1 && st.bodyBytes+int64(len(data)) > st.declBodyBytes {
 		err := fmt.Errorf("sender tried to send more than declared Content-Length of %d bytes", st.declBodyBytes)
 		st.body.CloseWithError(err)
-		return StreamError{id, ErrCodeStreamClosed, err.Error()}
+		// RFC 7540, sec 8.1.2.6: A request or response is also malformed if the
+		// value of a content-length header field does not equal the sum of the
+		// DATA frame payload lengths that form the body.
+		return StreamError{id, ErrCodeProtocol, err.Error()}
 	}
 	if f.Length > 0 {
 		// Check whether the client has flow control quota.

--- a/bfe_http2/server_test.go
+++ b/bfe_http2/server_test.go
@@ -3005,3 +3005,22 @@ func TestNoRstPostAfterGOAWAY(t *testing.T) {
 	}
 
 }
+
+func TestServer_Rejects_TooSmall(t *testing.T) {
+	testServerResponse(t, func(w http.ResponseWriter, r *http.Request) error {
+		return nil
+	}, func(st *serverTester) {
+		st.writeHeaders(HeadersFrameParam{
+			StreamID: 1, // clients send odd numbers
+			BlockFragment: st.encodeHeader(
+				":method", "POST",
+				"content-length", "4",
+			),
+			EndStream:  false, // to say DATA frames are coming
+			EndHeaders: true,
+		})
+		st.writeData(1, true, []byte("12345"))
+
+		st.wantRSTStream(1, ErrCodeProtocol)
+	})
+}


### PR DESCRIPTION
Signed-off-by: xiaoyuqi <xiaoyuqi@baidu.com>
#450 
sync http2 [commit](https://github.com/golang/net/commit/9ef9f5bb98a1fdc41f8cf6c250a4404b4085e389)