### PR TITLE
support basic route rule

### DIFF
--- a/bfe_config/bfe_route_conf/route_rule_conf/basic_rule_tree.go
+++ b/bfe_config/bfe_route_conf/route_rule_conf/basic_rule_tree.go
@@ -1,0 +1,218 @@
+// Copyright (c) 2019 The BFE Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// trees for matching basic route rule : (host+path) -> clusterName
+
+package route_rule_conf
+
+import (
+	"fmt"
+	"strings"
+)
+
+import (
+	"github.com/armon/go-radix"
+)
+
+import (
+	"github.com/bfenetworks/bfe/bfe_util/string_reverse"
+)
+
+const (
+	treeMatchExact    = iota // index to exact match tree
+	treeMatchWildcard        // index to wildcard match tree
+	treeMatchTypeNum         // index to exact match tree
+)
+
+type hostTrees [treeMatchTypeNum]*radix.Tree // trees for host match
+type pathTrees [treeMatchTypeNum]*radix.Tree // trees for path match
+
+// BasicRouteRuleTree implements radix trees for host+path matching
+// hostTree (key:hostname, value:pathTree)
+// pathTree (key:path, value:clusterName)
+type BasicRouteRuleTree struct {
+	hosts hostTrees
+}
+
+func NewBasicRouteRuleTree() *BasicRouteRuleTree {
+	return &BasicRouteRuleTree{
+		hosts: [treeMatchTypeNum]*radix.Tree{radix.New(), radix.New()},
+	}
+}
+
+// Insert adds a new basic route rule into BasicRouteRuleTree
+// key: hostname, value: pathTrees
+func (r *BasicRouteRuleTree) Insert(ruleConf *BasicRouteRuleFile) error {
+	if len(ruleConf.Hostname) == 0 {
+		ruleConf.Hostname = append(ruleConf.Hostname, "*")
+	}
+
+	if len(ruleConf.Path) == 0 {
+		ruleConf.Path = append(ruleConf.Path, "*")
+	}
+
+	for _, host := range ruleConf.Hostname {
+		if host == "" {
+			// not allow
+			return fmt.Errorf("hostname is empty string")
+		}
+
+		pathTree := r.hosts.insert(host)
+		for _, path := range ruleConf.Path {
+			if err := pathTree.insert(path, *ruleConf.ClusterName); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+// insert adds a new node in hostTrees, key: hostname, value: pathTrees
+// return node's value: pathTrees
+func (ht *hostTrees) insert(host string) pathTrees {
+	var treeType int
+	var key string
+
+	// remove * from wildcard host
+	// *.bar.foo.com -> .bar.foo.com
+	if host[0] == '*' {
+		key = host[1:]
+		treeType = treeMatchWildcard
+	} else {
+		key = host
+		treeType = treeMatchExact
+	}
+
+	// call ReverseFqdnHost reverse hostname
+	// for case insensitive comparing, convert the reversed hostname to uppercase
+	// .bar.foo.com -> MOC.OOF.RAB.
+	key = strings.ToUpper(string_reverse.ReverseFqdnHost(key))
+
+	// return pathTree if already existed
+	if value, found := ht[treeType].Get(key); found {
+		return value.(pathTrees)
+	}
+
+	// no host found, insert new node
+	value := pathTrees{radix.New(), radix.New()}
+	ht[treeType].Insert(key, value)
+
+	return value
+}
+
+// get returns pathTree for hostname
+func (ht *hostTrees) get(host string) (pathTrees, bool) {
+	// convert key to uppercase for case insensitive comparing
+	// baz.bar.foo.com -> MOC.OOF.RAB.ZAB
+	key := strings.ToUpper(string_reverse.ReverseFqdnHost(host))
+
+	//exact match firstly
+	if value, found := ht[treeMatchExact].Get(key); found {
+		return value.(pathTrees), true
+	}
+
+	// try wildcard match if exact match fail
+	// note: * only match one label in hostname.
+	// For example: *.aaa.com can match with bbb.aaa.com, but can't match with ccc.bbb.aaa.com
+	if matchedPrefix, value, found := ht[treeMatchWildcard].LongestPrefix(key); found {
+
+		// get remaining(unmatched) part of a hostname without prefix
+		// For example:
+		// 		wildcard host *.bar.foo.com, key in tree would be MOC.OOF.RAB.
+		// 		to host baz.bar.foo.com, key for matching would be MOC.OOF.RAB.ZAB
+		// 		so, in this case, remainingPart = ZAB
+		remainingPart := strings.TrimPrefix(key, matchedPrefix)
+
+		// the remaining part should not contain "."
+		// if the remaining part contain ".", it means '*' matches multiple labels in hostname, which is not allowed
+		if strings.Contains(remainingPart, ".") {
+			// not matched, try again to match empty string "", which match any hostname
+			if value, found := ht[treeMatchWildcard].Get(""); found {
+				// matched with ""
+				return value.(pathTrees), true
+			}
+		} else {
+			// matched with wildcard host
+			return value.(pathTrees), true
+		}
+	}
+
+	return pathTrees{}, false
+}
+
+// insert adds a new node in pathTree
+// key : path, value: clusterName
+func (pt *pathTrees) insert(path, cluster string) error {
+	var treeType int
+	var key string
+
+	if len(path) == 0 {
+		return fmt.Errorf("empth path is not allowed")
+	}
+
+	if path[len(path)-1] == '*' {
+		// wildcard path, remove trailing *
+		key = path[:len(path)-1]
+
+		// append slash if no trailing one
+		// /foo, /foo/ or /foo/bar can match with /foo*, but /foobar can not
+		if len(key) > 0 && key[len(key)-1] != '/' {
+			key = key + "/"
+		}
+		treeType = treeMatchWildcard
+	} else {
+		key = path
+		treeType = treeMatchExact
+	}
+
+	if old, updated := pt[treeType].Insert(key, cluster); updated {
+		// if key exist, return error
+		return fmt.Errorf("path[%s] is duplicated in same host, existing cluster: %s", path, old)
+	}
+
+	return nil
+}
+
+// get returns node's value (cluster name) referenced by a path
+func (pt *pathTrees) get(path string) (string, bool) {
+	// exact match firstly
+	if value, found := pt[treeMatchExact].Get(path); found {
+		return value.(string), true
+	}
+
+	// append trailing slash
+	if len(path) > 0 && path[len(path)-1] != '/' {
+		path = path + "/"
+	}
+
+	// wildcard match
+	if _, value, found := pt[treeMatchWildcard].LongestPrefix(path); found {
+		return value.(string), true
+	}
+
+	return "", false
+}
+
+// Get returns cluster name by host and path
+func (r *BasicRouteRuleTree) Get(host, path string) (string, bool) {
+	// match host to get pathTree
+	pathTree, found := r.hosts.get(host)
+	if !found {
+		return "", false
+	}
+
+	// match path
+	return pathTree.get(path)
+}

--- a/bfe_config/bfe_route_conf/route_rule_conf/basic_rule_tree_test.go
+++ b/bfe_config/bfe_route_conf/route_rule_conf/basic_rule_tree_test.go
@@ -1,0 +1,402 @@
+// Copyright (c) 2019 The BFE Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package route_rule_conf
+
+import (
+	"testing"
+)
+
+func TestHostMatchInBasicRuleTree(t *testing.T) {
+
+	cluster := "c1"
+	rule := &BasicRouteRuleFile{
+		Hostname:    nil,
+		Path:        nil,
+		ClusterName: &cluster,
+	}
+
+	rule.Hostname = append(rule.Hostname, "")
+	rt := NewBasicRouteRuleTree()
+	if ret := rt.Insert(rule); ret == nil {
+		t.Errorf("insert empty host is not allowed")
+	}
+
+	rule.Hostname = nil
+	rule.Hostname = append(rule.Hostname, "*")
+	rt.Insert(rule)
+
+	c, ok := rt.Get("*", "/")
+	if !ok || c != cluster {
+		t.Errorf("should match")
+	}
+
+	c, ok = rt.Get("any", "/foo")
+	if !ok || c != cluster {
+		t.Errorf("should match")
+	}
+
+	c, ok = rt.Get("bar.foo.com", "/foo")
+	if !ok || c != cluster {
+		t.Errorf("should match")
+	}
+
+	rule.Hostname = nil
+	rule.Hostname = append(rule.Hostname, "*.com")
+	rt = NewBasicRouteRuleTree()
+	rt.Insert(rule)
+
+	c, ok = rt.Get("foo.com", "/foo")
+	if !ok || c != cluster {
+		t.Errorf("should match")
+	}
+	_, ok = rt.Get("bar.foo.com", "/foo")
+	if ok {
+		t.Errorf("should not match")
+	}
+
+	rule.Hostname = nil
+	rule.Hostname = append(rule.Hostname, "*.foo.com")
+	rt = NewBasicRouteRuleTree()
+	rt.Insert(rule)
+
+	c, ok = rt.Get("bar.foo.com", "/")
+	if !ok || c != cluster {
+		t.Errorf("should match")
+	}
+	c, ok = rt.Get("foo.com", "/")
+	if ok {
+		t.Errorf("should not match *")
+	}
+
+	rule.Hostname = nil
+	rule.Hostname = append(rule.Hostname, "foo.com")
+	rule.Hostname = append(rule.Hostname, "bar.com")
+
+	rt = NewBasicRouteRuleTree()
+	rt.Insert(rule)
+	c, ok = rt.Get("foo.com", "/")
+	if !ok || c != cluster {
+		t.Errorf("should match")
+	}
+	rt.Insert(rule)
+	c, ok = rt.Get("bar.com", "/")
+	if !ok || c != cluster {
+		t.Errorf("should match")
+	}
+
+	rt = NewBasicRouteRuleTree()
+	rule.Hostname = nil
+	rule.Hostname = append(rule.Hostname, "foo.com")
+	cluster1 := "c1"
+	rule.ClusterName = &cluster1
+	rt.Insert(rule)
+
+	rule.Hostname = nil
+	rule.Hostname = append(rule.Hostname, "bar.com")
+	cluster2 := "c2"
+	rule.ClusterName = &cluster2
+	rt.Insert(rule)
+
+	c, ok = rt.Get("foo.com", "/")
+	if !ok || c != cluster1 {
+		t.Errorf("should match")
+	}
+	c, ok = rt.Get("bar.com", "/")
+	if !ok || c != cluster2 {
+		t.Errorf("should match")
+	}
+
+	rule.Hostname = nil
+	rule.Hostname = append(rule.Hostname, "*.bar.com")
+	cluster3 := "c3"
+	rule.ClusterName = &cluster3
+	rt.Insert(rule)
+
+	c, ok = rt.Get("baz.bar.com", "/")
+	if !ok || c != cluster3 {
+		t.Errorf("should match")
+	}
+
+}
+
+func TestPathMatchInBasicRuleTree(t *testing.T) {
+	cluster := "c1"
+	rule := &BasicRouteRuleFile{
+		Hostname:    nil,
+		Path:        nil,
+		ClusterName: &cluster,
+	}
+
+	rule.Path = append(rule.Path, "")
+	rt := NewBasicRouteRuleTree()
+	if ret := rt.Insert(rule); ret == nil {
+		t.Errorf("empty path is not allowed")
+	}
+
+	rule.Path = nil
+	rule.Path = append(rule.Path, "*")
+	rt.Insert(rule)
+
+	c, ok := rt.Get("any", "/foo")
+	if !ok || c != cluster {
+		t.Errorf("should match")
+	}
+
+	c, ok = rt.Get("foo.com", "/foo")
+	if !ok || c != cluster {
+		t.Errorf("should match")
+	}
+
+	c, ok = rt.Get("foo.com", "foo")
+	if !ok || c != cluster {
+		t.Errorf("should match")
+	}
+
+	c, ok = rt.Get("*", "/foo")
+	if !ok || c != cluster {
+		t.Errorf("should match")
+	}
+
+	rule.Path = nil
+	rule.Path = append(rule.Path, "/")
+	rt = NewBasicRouteRuleTree()
+	rt.Insert(rule)
+
+	c, ok = rt.Get("foo.com", "/")
+	if !ok || c != cluster {
+		t.Errorf("should match")
+	}
+
+	c, ok = rt.Get("foo.com", "/foo")
+	if ok {
+		t.Errorf("should not match")
+	}
+
+	rule.Path = nil
+	rule.Path = append(rule.Path, "/*")
+	rt = NewBasicRouteRuleTree()
+	rt.Insert(rule)
+
+	c, ok = rt.Get("foo.com", "/")
+	if !ok || c != cluster {
+		t.Errorf("should match")
+	}
+	c, ok = rt.Get("foo.com", "/foo")
+	if !ok || c != cluster {
+		t.Errorf("should match")
+	}
+	c, ok = rt.Get("foo.com", "/foo/bar")
+	if !ok || c != cluster {
+		t.Errorf("should match")
+	}
+	c, ok = rt.Get("foo.com", "foo")
+	if ok {
+		t.Errorf("should not match")
+	}
+
+	rule.Path = nil
+	rule.Path = append(rule.Path, "/foo")
+	rt = NewBasicRouteRuleTree()
+	rt.Insert(rule)
+
+	c, ok = rt.Get("foo.com", "/foo")
+	if !ok || c != cluster {
+		t.Errorf("should match")
+	}
+	c, ok = rt.Get("foo.com", "/bar")
+	if ok {
+		t.Errorf("should not match")
+	}
+	c, ok = rt.Get("foo.com", "/foobar")
+	if ok {
+		t.Errorf("should not match")
+	}
+	c, ok = rt.Get("foo.com", "/foo/")
+	if ok {
+		t.Errorf("should not match")
+	}
+
+	rule.Path = nil
+	rule.Path = append(rule.Path, "/foo/")
+	rt = NewBasicRouteRuleTree()
+	rt.Insert(rule)
+	c, ok = rt.Get("foo.com", "/foo/")
+	if !ok || c != cluster {
+		t.Errorf("should match")
+	}
+	c, ok = rt.Get("foo.com", "/foo")
+	if ok {
+		t.Errorf("should not match")
+	}
+
+	rule.Path = nil
+	rule.Path = append(rule.Path, "/foo*")
+	rt = NewBasicRouteRuleTree()
+	rt.Insert(rule)
+	c, ok = rt.Get("foo.com", "/foo/")
+	if !ok || c != cluster {
+		t.Errorf("should match")
+	}
+	c, ok = rt.Get("foo.com", "/foo")
+	if !ok || c != cluster {
+		t.Errorf("should match")
+	}
+	c, ok = rt.Get("foo.com", "/foobar")
+	if ok {
+		t.Errorf("should not match")
+	}
+	c, ok = rt.Get("foo.com", "/bar")
+	if ok {
+		t.Errorf("should not match")
+	}
+
+	rule.Path = nil
+	rule.Path = append(rule.Path, "/foo/*")
+	rt = NewBasicRouteRuleTree()
+	rt.Insert(rule)
+	c, ok = rt.Get("foo.com", "/foo/")
+	if !ok || c != cluster {
+		t.Errorf("should match")
+	}
+	c, ok = rt.Get("foo.com", "/foo/bar")
+	if !ok || c != cluster {
+		t.Errorf("should match")
+	}
+	c, ok = rt.Get("foo.com", "/foo")
+	if !ok || c != cluster {
+		t.Errorf("should match")
+	}
+
+	rule.Path = nil
+	rule.Path = append(rule.Path, "/aaa/bb*")
+	rt = NewBasicRouteRuleTree()
+	rt.Insert(rule)
+	c, ok = rt.Get("foo.com", "/aaa/bbb")
+	if ok {
+		t.Errorf("should not match")
+	}
+
+	rule.Path = nil
+	rule.Path = append(rule.Path, "/aaa/bbb*")
+	rt = NewBasicRouteRuleTree()
+	rt.Insert(rule)
+	c, ok = rt.Get("foo.com", "/aaa/bbb")
+	if !ok || c != cluster {
+		t.Errorf("should match")
+	}
+	c, ok = rt.Get("foo.com", "/aaa/bbb/")
+	if !ok || c != cluster {
+		t.Errorf("should match")
+	}
+	c, ok = rt.Get("foo.com", "/aaa/bbbxyz")
+	if ok {
+		t.Errorf("should not match")
+	}
+	c, ok = rt.Get("foo.com", "/aaa/bbb/xyz")
+	if !ok || c != cluster {
+		t.Errorf("should match")
+	}
+
+	rule.Path = nil
+	rule.Path = append(rule.Path, "/aaa/bbb/*")
+	rt = NewBasicRouteRuleTree()
+	rt.Insert(rule)
+	c, ok = rt.Get("foo.com", "/aaa/bbb")
+	if !ok || c != cluster {
+		t.Errorf("should match")
+	}
+
+	rt = NewBasicRouteRuleTree()
+	rule.Path = nil
+	rule.Path = append(rule.Path, "/*")
+	cluster1 := "c1"
+	rule.ClusterName = &cluster1
+	rt.Insert(rule)
+
+	rule.Path = nil
+	rule.Path = append(rule.Path, "/aaa*")
+	cluster2 := "c2"
+	rule.ClusterName = &cluster2
+	rt.Insert(rule)
+
+	c, ok = rt.Get("foo.com", "/aaa/ccc")
+	if !ok || c != cluster2 {
+		t.Errorf("should match")
+	}
+
+	rule.Path = nil
+	rule.Path = append(rule.Path, "/aaa/bbb*")
+	cluster3 := "c3"
+	rule.ClusterName = &cluster3
+	rt.Insert(rule)
+
+	c, ok = rt.Get("foo.com", "/aaa/bbb")
+	if !ok || c != cluster3 {
+		t.Errorf("should match")
+	}
+	c, ok = rt.Get("foo.com", "/ccc")
+	if !ok || c != cluster1 {
+		t.Errorf("should match")
+	}
+
+	rt = NewBasicRouteRuleTree()
+	rule.Path = nil
+	rule.Path = append(rule.Path, "/foo")
+	cluster1 = "c1"
+	rule.ClusterName = &cluster1
+	rt.Insert(rule)
+
+	rule.Path = nil
+	rule.Path = append(rule.Path, "/foo*")
+	cluster2 = "c2"
+	rule.ClusterName = &cluster2
+	rt.Insert(rule)
+
+	c, ok = rt.Get("foo.com", "/foo")
+	if !ok || c != cluster1 {
+		t.Errorf("should match")
+	}
+
+}
+
+func TestHostAndPathMatchInBasicRuleTree(t *testing.T) {
+	cluster := "c1"
+	rule := &BasicRouteRuleFile{
+		Hostname:    nil,
+		Path:        nil,
+		ClusterName: &cluster,
+	}
+
+	rule.Hostname = append(rule.Hostname, "aaa.foo.com")
+	rule.Hostname = append(rule.Hostname, "bbb.foo.com")
+	rule.Hostname = append(rule.Hostname, "ccc.foo.com")
+	rule.Path = append(rule.Path, "/aaa/bbb")
+	rule.Path = append(rule.Path, "/ccc/ddd")
+	rule.Path = append(rule.Path, "/eee/fff*")
+	cluster1 := "c1"
+	rule.ClusterName = &cluster1
+	rt := NewBasicRouteRuleTree()
+	rt.Insert(rule)
+
+	c, ok := rt.Get("aaa.foo.com", "/aaa/bbb")
+	if !ok || c != cluster1 {
+		t.Errorf("should match")
+	}
+	c, ok = rt.Get("ccc.foo.com", "/eee/fff/ggg")
+	if !ok || c != cluster1 {
+		t.Errorf("should match")
+	}
+
+}

--- a/bfe_config/bfe_route_conf/route_rule_conf/route_table_load_test.go
+++ b/bfe_config/bfe_route_conf/route_rule_conf/route_table_load_test.go
@@ -26,9 +26,83 @@ func TestLoad(t *testing.T) {
 	rt, err := RouteConfLoad(fn)
 	if err != nil {
 		t.Errorf("route conf load error %s", err)
+		return
 	}
 
-	if len(rt.RuleMap["product-b"]) != 2 {
-		t.Errorf("product-2 condition len is not 2")
+	if len(rt.AdvancedRuleMap["product-b"]) != 2 {
+		t.Errorf("product-b condition len is not 2")
+	}
+}
+func TestLoad1(t *testing.T) {
+	pwd, _ := os.Getwd()
+	fn := fmt.Sprintf("%s/testdata/basic_route_rule1.data", pwd)
+	rt, err := RouteConfLoad(fn)
+	if err != nil {
+		t.Errorf("route conf load error %s", err)
+		return
+	}
+
+	if len(rt.BasicRuleMap["example_product"]) != 3 {
+		t.Errorf("example_product rule number is not 3")
+	}
+}
+func TestLoad2(t *testing.T) {
+	pwd, _ := os.Getwd()
+	fn := fmt.Sprintf("%s/testdata/basic_route_rule2.data", pwd)
+	_, err := RouteConfLoad(fn)
+	if err == nil {
+		t.Errorf("route conf load should failed")
+	}
+
+}
+
+func TestLoad3(t *testing.T) {
+	pwd, _ := os.Getwd()
+	fn := fmt.Sprintf("%s/testdata/basic_route_rule3.data", pwd)
+	rt, err := RouteConfLoad(fn)
+	if err != nil {
+		t.Errorf("route conf load error %s", err)
+		return
+	}
+
+	if len(rt.BasicRuleMap["example_product"]) != 3 {
+		t.Errorf("example_product len is not 3")
+	}
+
+}
+
+func TestLoad4(t *testing.T) {
+	pwd, _ := os.Getwd()
+	fn := fmt.Sprintf("%s/testdata/basic_route_rule4.data", pwd)
+	_, err := RouteConfLoad(fn)
+	if err == nil {
+		t.Errorf("route conf load should fail ")
+	}
+}
+
+func TestLoad5(t *testing.T) {
+	pwd, _ := os.Getwd()
+	fn := fmt.Sprintf("%s/testdata/basic_route_rule5.data", pwd)
+	_, err := RouteConfLoad(fn)
+	if err == nil {
+		t.Errorf("route conf load should fail")
+	}
+}
+
+func TestLoad6(t *testing.T) {
+	pwd, _ := os.Getwd()
+	fn := fmt.Sprintf("%s/testdata/basic_route_rule6.data", pwd)
+	_, err := RouteConfLoad(fn)
+	if err == nil {
+		t.Errorf("route conf load should fail")
+	}
+}
+
+func TestLoad7(t *testing.T) {
+	pwd, _ := os.Getwd()
+	fn := fmt.Sprintf("%s/testdata/basic_route_rule7.data", pwd)
+	_, err := RouteConfLoad(fn)
+	if err == nil {
+		t.Errorf("route conf load should fail")
 	}
 }

--- a/bfe_config/bfe_route_conf/route_rule_conf/testdata/basic_route_rule1.data
+++ b/bfe_config/bfe_route_conf/route_rule_conf/testdata/basic_route_rule1.data
@@ -1,0 +1,20 @@
+{
+    "Version": "685",
+    "BasicRule":{
+  		"example_product" : [
+			{
+				"Hostname": ["www.a.com","*"],
+				"Path":["/a","/b"],
+				"ClusterName": "cluster_example_1"
+			},
+			{
+				"Hostname": ["*.foo.com","*.bar.com"],
+				"ClusterName": "cluster_example_2"
+			},
+			{
+				"Path":["/a*","/b*"],
+				"ClusterName": "cluster_example_3"
+			}
+		]
+    }
+}

--- a/bfe_config/bfe_route_conf/route_rule_conf/testdata/basic_route_rule2.data
+++ b/bfe_config/bfe_route_conf/route_rule_conf/testdata/basic_route_rule2.data
@@ -1,0 +1,20 @@
+{
+    "Version": "685",
+    "BasicRule":{
+  		"example_product" : [
+			{
+				"ClusterName": "cluster_example_1"
+			},
+			{
+				"Hostname": ["www.foo.com",""],
+				"Path":["/a","/b"],
+				"ClusterName": "cluster_example_2"
+			},
+			{
+				"Hostname": ["","www.ddd.com"],
+				"Path":["/a","/b"],
+				"ClusterName": "ADVANCED_MODE"
+			}
+		]
+    }
+}

--- a/bfe_config/bfe_route_conf/route_rule_conf/testdata/basic_route_rule3.data
+++ b/bfe_config/bfe_route_conf/route_rule_conf/testdata/basic_route_rule3.data
@@ -1,0 +1,46 @@
+{
+    "Version": "685",
+    "ProductRule": {
+        "product-a": [
+            {
+                "ClusterName": "cluster_a",
+                "Cond": "default_t()"
+            }
+        ],
+        "product-b": [
+            {
+                "ClusterName": "cluster_b1",
+                "Cond": "req_header_key_in(\"X-Bd-Bwsc\")"
+            },
+            {
+                "ClusterName": "cluster_b2",
+                "Cond": "default_t()"
+            }
+        ],
+        "example_product": [
+            {
+                "ClusterName": "cluster_example",
+                "Cond": "default_t()"
+            }
+        ]
+    },
+    "BasicRule":{
+       "example_product" : [
+     	{
+     		"Hostname": ["www.a.com","www.b.com"],
+		    "Path":["/a","/b"],
+		    "ClusterName": "cluster_example_1"
+	    },
+        {
+	       "Hostname": ["*.foo.com","www.bar.com"],
+	       "Path":["/a","/b"],
+	       "ClusterName": "cluster_example_2"
+       },
+       {
+	       "Hostname": ["*.ccc.com","www.ddd.com"],
+	       "Path":["/a","/b"],
+	       "ClusterName": "ADVANCED_MODE"
+       }
+       ]
+    }
+}

--- a/bfe_config/bfe_route_conf/route_rule_conf/testdata/basic_route_rule4.data
+++ b/bfe_config/bfe_route_conf/route_rule_conf/testdata/basic_route_rule4.data
@@ -1,0 +1,20 @@
+{
+    "Version": "685",
+    "ProductRule": {
+        "example_product": [
+            {
+                "ClusterName": "cluster_example",
+                "Cond": "default_t()"
+            }
+        ]
+    },
+    "BasicRule":{
+  		"example_product" : [
+			{
+				"Hostname": ["*abc.a.com","www.b.com"],
+				"Path":["/a","/b"],
+				"ClusterName": "cluster_example_1"
+			}
+		]
+    }
+}

--- a/bfe_config/bfe_route_conf/route_rule_conf/testdata/basic_route_rule5.data
+++ b/bfe_config/bfe_route_conf/route_rule_conf/testdata/basic_route_rule5.data
@@ -1,0 +1,20 @@
+{
+    "Version": "685",
+    "ProductRule": {
+        "example_product": [
+            {
+                "ClusterName": "cluster_example",
+                "Cond": "default_t()"
+            }
+        ]
+    },
+    "BasicRule":{
+  		"example_product" : [
+			{
+				"Hostname": ["abc*.a.com","www.b.com"],
+				"Path":["/a","/b"],
+				"ClusterName": "cluster_example_1"
+			}
+		]
+    }
+}

--- a/bfe_config/bfe_route_conf/route_rule_conf/testdata/basic_route_rule6.data
+++ b/bfe_config/bfe_route_conf/route_rule_conf/testdata/basic_route_rule6.data
@@ -1,0 +1,20 @@
+{
+    "Version": "685",
+    "ProductRule": {
+        "example_product": [
+            {
+                "ClusterName": "cluster_example",
+                "Cond": "default_t()"
+            }
+        ]
+    },
+    "BasicRule":{
+  		"example_product" : [
+			{
+				"Hostname": ["*.*.a.com","www.b.com"],
+				"Path":["/a","/b"],
+				"ClusterName": "cluster_example_1"
+			}
+		]
+    }
+}

--- a/bfe_config/bfe_route_conf/route_rule_conf/testdata/basic_route_rule7.data
+++ b/bfe_config/bfe_route_conf/route_rule_conf/testdata/basic_route_rule7.data
@@ -1,0 +1,20 @@
+{
+    "Version": "685",
+    "ProductRule": {
+        "example_product": [
+            {
+                "ClusterName": "cluster_example",
+                "Cond": "default_t()"
+            }
+        ]
+    },
+    "BasicRule":{
+  		"example_product" : [
+			{
+				"Hostname": ["*.foo.com"],
+				"Path":["/a/*/*","/b"],
+				"ClusterName": "cluster_example_1"
+			}
+		]
+    }
+}

--- a/bfe_route/host_table.go
+++ b/bfe_route/host_table.go
@@ -27,6 +27,7 @@ import (
 	"github.com/bfenetworks/bfe/bfe_config/bfe_route_conf/route_rule_conf"
 	"github.com/bfenetworks/bfe/bfe_config/bfe_route_conf/vip_rule_conf"
 	"github.com/bfenetworks/bfe/bfe_route/trie"
+	"github.com/bfenetworks/bfe/bfe_util/string_reverse"
 )
 
 var (
@@ -45,8 +46,12 @@ type HostTable struct {
 	vipTable       vip_rule_conf.Vip2Product      // for get proudct name by vip (backup)
 	defaultProduct string                         // default product name
 
-	hostTrie          *trie.Trie
-	productRouteTable route_rule_conf.ProductRouteRule // all product's route rules
+	hostTrie *trie.Trie
+
+	productBasicRouteTable    route_rule_conf.ProductBasicRouteRule    // all product's basic route rules list
+	productBasicRouteTree     route_rule_conf.ProductBasicRouteTree    // all product's basic route rules tree
+	productAdvancedRouteTable route_rule_conf.ProductAdvancedRouteRule // all product's advanced route rules
+
 }
 
 type Versions struct {
@@ -56,10 +61,11 @@ type Versions struct {
 }
 
 type Status struct {
-	HostTableSize         int
-	HostTagTableSize      int
-	VipTableSize          int
-	ProductRouteTableSize int
+	HostTableSize              int
+	HostTagTableSize           int
+	VipTableSize               int
+	ProductRouteTableSize      int
+	ProductBasicRouteTableSize int
 }
 
 type route struct {
@@ -90,7 +96,9 @@ func (t *HostTable) updateVipTable(conf vip_rule_conf.VipConf) {
 // updateRouteTable updates product Route Rule
 func (t *HostTable) updateRouteTable(conf *route_rule_conf.RouteTableConf) {
 	t.versions.ProductRoute = conf.Version
-	t.productRouteTable = conf.RuleMap
+	t.productBasicRouteTree = conf.BasicRuleTree
+	t.productBasicRouteTable = conf.BasicRuleMap
+	t.productAdvancedRouteTable = conf.AdvancedRuleMap
 }
 
 // Update updates host table
@@ -133,8 +141,26 @@ func (t *HostTable) LookupHostTagAndProduct(req *bfe_basic.Request) error {
 func (t *HostTable) LookupCluster(req *bfe_basic.Request) error {
 	var clusterName string
 
-	// get route rules
-	rules, ok := t.productRouteTable[req.Route.Product]
+	// match basic route rules
+	basicRules, ok := t.productBasicRouteTree[req.Route.Product]
+	if ok {
+		host := strings.SplitN(req.HttpRequest.Host, ":", 2)[0]
+
+		path := ""
+		if req.HttpRequest.URL != nil {
+			path = req.HttpRequest.URL.Path
+		}
+
+		clusterName, found := basicRules.Get(host, path)
+		if found && clusterName != route_rule_conf.AdvancedMode {
+			// set clusterName
+			req.Route.ClusterName = clusterName
+			return nil
+		}
+	}
+
+	// match advanced route rules
+	rules, ok := t.productAdvancedRouteTable[req.Route.Product]
 	if !ok {
 		req.Route.ClusterName = ""
 		req.Route.Error = ErrNoProductRule
@@ -215,7 +241,8 @@ func (t *HostTable) GetVersions() Versions {
 // GetStatus return status of host table.
 func (t *HostTable) GetStatus() Status {
 	var s Status
-	s.ProductRouteTableSize = len(t.productRouteTable)
+	s.ProductBasicRouteTableSize = len(t.productBasicRouteTable)
+	s.ProductRouteTableSize = len(t.productAdvancedRouteTable)
 	s.HostTableSize = len(t.hostTable)
 	s.HostTagTableSize = len(t.hostTagTable)
 	s.VipTableSize = len(t.vipTable)
@@ -229,7 +256,7 @@ func (t *HostTable) findHostRoute(host string) (route, error) {
 
 	host = strings.ToLower(host)
 	// get host-tag by hostname
-	match, ok := t.hostTrie.Get(strings.Split(reverseFqdnHost(hostnameStrip(host)), "."))
+	match, ok := t.hostTrie.Get(strings.Split(string_reverse.ReverseFqdnHost(hostnameStrip(host)), "."))
 	if ok {
 		// get route success, return
 		return match.(route), nil
@@ -255,28 +282,13 @@ func hostnameStrip(hostname string) string {
 	return strings.Split(hostname, ":")[0]
 }
 
-// reverseFqdnHost reverse host to make prefix tree smaller.
-// i.e.: www.baidu.com news.baidu.com -> moc.udiab.swen moc.udiab.www will have same prefix
-func reverseFqdnHost(host string) string {
-	r := []rune(host)
-	for i, j := 0, len(r)-1; i < j; i, j = i+1, j-1 {
-		r[i], r[j] = r[j], r[i]
-	}
-
-	if len(r) > 0 && r[0] == '.' {
-		r = r[1:]
-	}
-
-	return string(r)
-}
-
 func buildHostRoute(conf host_rule_conf.HostConf) *trie.Trie {
 	hostTrie := trie.NewTrie()
 
 	for host, tag := range conf.HostMap {
 		host = strings.ToLower(host)
 		product := conf.HostTagMap[tag]
-		hostTrie.Set(strings.Split(reverseFqdnHost(host), "."), route{product: product, tag: tag})
+		hostTrie.Set(strings.Split(string_reverse.ReverseFqdnHost(host), "."), route{product: product, tag: tag})
 	}
 
 	return hostTrie

--- a/bfe_route/server_data_conf.go
+++ b/bfe_route/server_data_conf.go
@@ -108,7 +108,7 @@ func (s *ServerDataConf) clusterTableLoad(clusterConf string) error {
 
 func (s *ServerDataConf) check() error {
 	// check product consistency in host and route
-	for product1 := range s.HostTable.productRouteTable {
+	for product1 := range s.HostTable.productAdvancedRouteTable {
 		find := false
 		for _, product2 := range s.HostTable.hostTagTable {
 			if product1 == product2 {
@@ -121,11 +121,34 @@ func (s *ServerDataConf) check() error {
 		}
 	}
 
-	// check cluster_name consistency in route and cluster_conf
-	for _, routeRules := range s.HostTable.productRouteTable {
+	for product1 := range s.HostTable.productBasicRouteTree {
+		find := false
+		for _, product2 := range s.HostTable.hostTagTable {
+			if product1 == product2 {
+				find = true
+				break
+			}
+		}
+		if !find {
+			return fmt.Errorf("product[%s] in route should exist in host!", product1)
+		}
+	}
+
+	// check cluster_name of advanced rule in route and cluster_conf
+	for _, routeRules := range s.HostTable.productAdvancedRouteTable {
 		for _, routeRule := range routeRules {
 			if _, err := s.ClusterTable.Lookup(routeRule.ClusterName); err != nil {
-				return fmt.Errorf("cluster[%s] in route should exist in cluster_conf",
+				return fmt.Errorf("cluster[%s] in advanced route should exist in cluster_conf",
+					routeRule.ClusterName)
+			}
+		}
+	}
+
+	// check cluster_name of basic rule table in route and cluster_conf
+	for _, routeRules := range s.HostTable.productBasicRouteTable {
+		for _, routeRule := range routeRules {
+			if _, err := s.ClusterTable.Lookup(routeRule.ClusterName); err != nil {
+				return fmt.Errorf("cluster[%s] in basic route should exist in cluster_conf",
 					routeRule.ClusterName)
 			}
 		}

--- a/bfe_util/string_reverse/string_reverse.go
+++ b/bfe_util/string_reverse/string_reverse.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2019 The BFE Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package string_reverse
+
+// ReverseFqdnHost reverse host.
+// i.e.: www.baidu.com news.baidu.com -> moc.udiab.swen moc.udiab.www will have same prefix
+func ReverseFqdnHost(host string) string {
+	r := []rune(host)
+	for i, j := 0, len(r)-1; i < j; i, j = i+1, j-1 {
+		r[i], r[j] = r[j], r[i]
+	}
+
+	if len(r) > 0 && r[0] == '.' {
+		r = r[1:]
+	}
+
+	return string(r)
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.13
 require (
 	github.com/abbot/go-http-auth v0.4.1-0.20181019201920-860ed7f246ff
 	github.com/andybalholm/brotli v1.0.0
+	github.com/armon/go-radix v1.0.0 // indirect
 	github.com/asergeyev/nradix v0.0.0-20170505151046-3872ab85bb56 // indirect
 	github.com/baidu/go-lib v0.0.0-20200819072111-21df249f5e6a
 	github.com/codahale/hdrhistogram v0.0.0-20161010025455-3a0bb77429bd // indirect


### PR DESCRIPTION
Add basic route rule support in bfe. Basic route rule means host+path routing, which describe how to route incoming HTTP request based on Host and Path in message header. Original route rule, based on condition expression, is renamed as advanced  route rule。
The basic host and path matching rule is same as description in k8s ingress. Please refer to  https://kubernetes.io/docs/concepts/services-networking/ingress/