### PR TITLE
basic rule routing, disable checking if cluster_name equals ADVANCED_MODE

### DIFF
--- a/bfe_route/server_data_conf.go
+++ b/bfe_route/server_data_conf.go
@@ -147,6 +147,10 @@ func (s *ServerDataConf) check() error {
 	// check cluster_name of basic rule table in route and cluster_conf
 	for _, routeRules := range s.HostTable.productBasicRouteTable {
 		for _, routeRule := range routeRules {
+			if routeRule.ClusterName == route_rule_conf.AdvancedMode {
+				continue
+			}
+
 			if _, err := s.ClusterTable.Lookup(routeRule.ClusterName); err != nil {
 				return fmt.Errorf("cluster[%s] in basic route should exist in cluster_conf",
 					routeRule.ClusterName)


### PR DESCRIPTION
Fix config checking in loading basic route rule, bypass cluster_name checking if cluster_name equals ADVANCED_MODE.