### PR TITLE
docs: add prerequisite glibc-static install_from_source.md

### DIFF
--- a/docs/en_us/installation/install_from_source.md
+++ b/docs/en_us/installation/install_from_source.md
@@ -3,6 +3,7 @@
 ## Prerequisites
 - golang 1.13+
 - git 2.0+
+- glibc-static 2.17+
 
 ## Download source code
 ```bash

--- a/docs/zh_cn/installation/install_from_source.md
+++ b/docs/zh_cn/installation/install_from_source.md
@@ -3,6 +3,7 @@
 ## 环境准备
 - golang 1.13+
 - git 2.0+
+- glibc-static 2.17+
 
 ## 源码下载
 ```bash


### PR DESCRIPTION
must install glibc-static first, then build bfe, otherwise it'll build failure, like below:

```bash
go build -ldflags "-X main.version=1.2.0-dev -X main.commit=ba960859904ff6bff45fb73f3dec9506ebefc904 -extldflags=-static"
# github.com/bfenetworks/bfe
/usr/lib/golang/pkg/tool/linux_amd64/link: running gcc failed: exit status 1
/usr/bin/ld: cannot find -lpthread
/usr/bin/ld: cannot find -ldl
/usr/bin/ld: cannot find -lc
collect2: error: ld returned 1 exit status
```