### PR TITLE
 A preliminary design  about Sighub reload conf

### DIFF
--- a/bfe_module/bfe_module.go
+++ b/bfe_module/bfe_module.go
@@ -35,6 +35,7 @@ type BfeModule interface {
 	// Name return name of module.
 	Name() string
 
+	// Load module conf
 	LoadConfData(query url.Values) error
 
 	// Init initializes the module.

--- a/bfe_module/bfe_module.go
+++ b/bfe_module/bfe_module.go
@@ -18,6 +18,7 @@ package bfe_module
 
 import (
 	"fmt"
+	"net/url"
 	"path"
 )
 
@@ -34,6 +35,8 @@ type BfeModule interface {
 	// Name return name of module.
 	Name() string
 
+	LoadConfData(query url.Values) error
+
 	// Init initializes the module.
 	//
 	// Params:
@@ -44,18 +47,18 @@ type BfeModule interface {
 }
 
 // moduleMap holds mappings from mod_name to module.
-var moduleMap = make(map[string]BfeModule)
+var ModuleMap = make(map[string]BfeModule)
 
-// modulesAll is an ordered list of all module names.
-var modulesAll = make([]string, 0)
+// ModulesAll is an ordered list of all module names.
+var ModulesAll = make([]string, 0)
 
 // modulesEnabled is list of enabled module names.
 var modulesEnabled = make([]string, 0)
 
-// AddModule adds module to moduleMap and modulesAll.
+// AddModule adds module to moduleMap and ModulesAll.
 func AddModule(module BfeModule) {
-	moduleMap[module.Name()] = module
-	modulesAll = append(modulesAll, module.Name())
+	ModuleMap[module.Name()] = module
+	ModulesAll = append(ModulesAll, module.Name())
 }
 
 type BfeModules struct {
@@ -72,7 +75,7 @@ func NewBfeModules() *BfeModules {
 
 // RegisterModule register work module, only work module be inited
 func (bm *BfeModules) RegisterModule(name string) error {
-	module, ok := moduleMap[name]
+	module, ok := ModuleMap[name]
 	if !ok {
 		return fmt.Errorf("no module for %s", name)
 	}
@@ -95,8 +98,8 @@ func (bm *BfeModules) GetModule(name string) BfeModule {
 //     - cr : root path for config
 func (bm *BfeModules) Init(cbs *BfeCallbacks, whs *web_monitor.WebHandlers, cr string) error {
 	// go through ALL available module names
-	// It is IMPORTANT to do init by the order defined in modulesAll
-	for _, name := range modulesAll {
+	// It is IMPORTANT to do init by the order defined in ModulesAll
+	for _, name := range ModulesAll {
 		// check whether this module is enabled
 		module, ok := bm.workModules[name]
 		if ok {
@@ -141,7 +144,7 @@ func ModConfDir(confRoot string, modName string) string {
 // ModuleStatusGetJSON get modules Available and modules Enabled.
 func ModuleStatusGetJSON() ([]byte, error) {
 	status := make(map[string][]string)
-	status["available"] = modulesAll
+	status["available"] = ModulesAll
 	status["enabled"] = modulesEnabled
 	return json.Marshal(status)
 }

--- a/bfe_module/bfe_module_test.go
+++ b/bfe_module/bfe_module_test.go
@@ -17,11 +17,16 @@ package bfe_module
 import (
 	"github.com/baidu/go-lib/web-monitor/web_monitor"
 	"github.com/stretchr/testify/assert"
+	"net/url"
 	"testing"
 )
 
 //mock module
 type testModule struct {
+}
+
+func (tm testModule) LoadConfData(query url.Values) error {
+	panic("implement me")
 }
 
 func (tm testModule) Name() string {

--- a/bfe_modules/bfe_modules.go
+++ b/bfe_modules/bfe_modules.go
@@ -89,7 +89,7 @@ var moduleList = []bfe_module.BfeModule{
 	// mod_secure_link
 	mod_secure_link.NewModuleSecureLink(),
 
-	//mod_waf
+	// mod_waf
 	mod_waf.NewModuleWaf(),
 
 	// mod_doh
@@ -114,7 +114,7 @@ var moduleList = []bfe_module.BfeModule{
 	// mod_errors
 	mod_errors.NewModuleErrors(),
 
-	//mod_markdown
+	// mod_markdown
 	mod_markdown.NewModuleMarkdown(),
 
 	// mod_compress

--- a/bfe_modules/bfe_modules.go
+++ b/bfe_modules/bfe_modules.go
@@ -72,6 +72,7 @@ var moduleList = []bfe_module.BfeModule{
 
 	// mod_block
 	// Requirement: After mod_logid
+	//  这里存在两个load
 	mod_block.NewModuleBlock(),
 
 	// mod_prison
@@ -88,7 +89,7 @@ var moduleList = []bfe_module.BfeModule{
 	// mod_secure_link
 	mod_secure_link.NewModuleSecureLink(),
 
-	// mod_waf
+	//mod_waf
 	mod_waf.NewModuleWaf(),
 
 	// mod_doh
@@ -113,7 +114,7 @@ var moduleList = []bfe_module.BfeModule{
 	// mod_errors
 	mod_errors.NewModuleErrors(),
 
-	// mod_markdown
+	//mod_markdown
 	mod_markdown.NewModuleMarkdown(),
 
 	// mod_compress
@@ -123,9 +124,11 @@ var moduleList = []bfe_module.BfeModule{
 	mod_key_log.NewModuleKeyLog(),
 
 	// mod_http_code
+	// load nil
 	mod_http_code.NewModuleHttpCode(),
 
 	// mod_access
+	// load nil
 	mod_access.NewModuleAccess(),
 }
 

--- a/bfe_modules/mod_access/mod_access.go
+++ b/bfe_modules/mod_access/mod_access.go
@@ -17,6 +17,7 @@ package mod_access
 import (
 	"bytes"
 	"fmt"
+	"net/url"
 )
 
 import (
@@ -48,6 +49,10 @@ func NewModuleAccess() *ModuleAccess {
 
 func (m *ModuleAccess) Name() string {
 	return m.name
+}
+
+func (m *ModuleAccess) LoadConfData(query url.Values) error {
+	return nil
 }
 
 func (m *ModuleAccess) ParseConfig(conf *ConfModAccess) error {

--- a/bfe_modules/mod_auth_basic/mod_auth_basic.go
+++ b/bfe_modules/mod_auth_basic/mod_auth_basic.go
@@ -67,7 +67,7 @@ func (m *ModuleAuthBasic) Name() string {
 	return m.name
 }
 
-func (m *ModuleAuthBasic) loadConfData(query url.Values) error {
+func (m *ModuleAuthBasic) LoadConfData(query url.Values) error {
 	path := query.Get("path")
 	if path == "" {
 		path = m.configPath
@@ -170,8 +170,8 @@ func (m *ModuleAuthBasic) Init(cbs *bfe_module.BfeCallbacks, whs *web_monitor.We
 	m.configPath = cfg.Basic.DataPath
 	openDebug = cfg.Log.OpenDebug
 
-	if err = m.loadConfData(nil); err != nil {
-		return fmt.Errorf("err in loadConfData(): %v", err)
+	if err = m.LoadConfData(nil); err != nil {
+		return fmt.Errorf("err in LoadConfData(): %v", err)
 	}
 
 	err = cbs.AddFilter(bfe_module.HandleFoundProduct, m.authBasicHandler)
@@ -184,9 +184,9 @@ func (m *ModuleAuthBasic) Init(cbs *bfe_module.BfeCallbacks, whs *web_monitor.We
 		return fmt.Errorf("%s.Init():RegisterHandlers(m.monitorHandlers): %v", m.name, err)
 	}
 
-	err = whs.RegisterHandler(web_monitor.WebHandleReload, m.name, m.loadConfData)
+	err = whs.RegisterHandler(web_monitor.WebHandleReload, m.name, m.LoadConfData)
 	if err != nil {
-		return fmt.Errorf("%s.Init(): RegisterHandler(m.loadConfData): %v", m.name, err)
+		return fmt.Errorf("%s.Init(): RegisterHandler(m.LoadConfData): %v", m.name, err)
 	}
 
 	return nil

--- a/bfe_modules/mod_auth_jwt/mod_auth_jwt.go
+++ b/bfe_modules/mod_auth_jwt/mod_auth_jwt.go
@@ -69,7 +69,7 @@ func (m *ModuleAuthJWT) Name() string {
 	return m.name
 }
 
-func (m *ModuleAuthJWT) loadConfData(query url.Values) error {
+func (m *ModuleAuthJWT) LoadConfData(query url.Values) error {
 	path := query.Get("path")
 	if path == "" {
 		path = m.configPath
@@ -199,8 +199,8 @@ func (m *ModuleAuthJWT) Init(cbs *bfe_module.BfeCallbacks, whs *web_monitor.WebH
 	m.configPath = cfg.Basic.DataPath
 	openDebug = cfg.Log.OpenDebug
 
-	if err = m.loadConfData(nil); err != nil {
-		return fmt.Errorf("err in loadConfData(): %v", err)
+	if err = m.LoadConfData(nil); err != nil {
+		return fmt.Errorf("err in LoadConfData(): %v", err)
 	}
 
 	err = cbs.AddFilter(bfe_module.HandleFoundProduct, m.authJWTHandler)
@@ -213,9 +213,9 @@ func (m *ModuleAuthJWT) Init(cbs *bfe_module.BfeCallbacks, whs *web_monitor.WebH
 		return fmt.Errorf("%s.Init():RegisterHandlers(m.monitorHandlers): %v", m.name, err)
 	}
 
-	err = whs.RegisterHandler(web_monitor.WebHandleReload, m.name, m.loadConfData)
+	err = whs.RegisterHandler(web_monitor.WebHandleReload, m.name, m.LoadConfData)
 	if err != nil {
-		return fmt.Errorf("%s.Init(): RegisterHandler(m.loadConfData): %v", m.name, err)
+		return fmt.Errorf("%s.Init(): RegisterHandler(m.LoadConfData): %v", m.name, err)
 	}
 
 	return nil

--- a/bfe_modules/mod_auth_request/mod_auth_request_test.go
+++ b/bfe_modules/mod_auth_request/mod_auth_request_test.go
@@ -35,7 +35,7 @@ const (
 	expectProduct = "example_product"
 )
 
-func TestLoadRuleData(t *testing.T) {
+func TestLoadConfData(t *testing.T) {
 	m := new(ModuleAuthRequest)
 	m.ruleTable = new(AuthRequestRuleTable)
 
@@ -43,15 +43,15 @@ func TestLoadRuleData(t *testing.T) {
 		"path": []string{"testdata/mod_auth_request/auth_request_rule.data"},
 	}
 
-	expectModVersion := "auth_request_rule.data=auth_request_rule_version"
-	modVersion, err := m.loadRuleData(query)
+	//expectModVersion := "auth_request_rule.data=auth_request_rule_version"
+	 err := m.LoadConfData(query)
 	if err != nil {
 		t.Fatalf("should have no error, but error is %v", err)
 	}
 
-	if modVersion != expectModVersion {
-		t.Fatalf("version shoule be %s, but it's %s", expectModVersion, modVersion)
-	}
+	//if modVersion != expectModVersion {
+	//	t.Fatalf("version shoule be %s, but it's %s", expectModVersion, modVersion)
+	//}
 
 	expectVersion := "auth_request_rule_version"
 	if m.ruleTable.version != expectVersion {

--- a/bfe_modules/mod_block/mod_block.go
+++ b/bfe_modules/mod_block/mod_block.go
@@ -106,8 +106,8 @@ func (m *ModuleBlock) loadGlobalIPTable(query url.Values) error {
 	return nil
 }
 
-// loadProductRuleConf load from config file.
-func (m *ModuleBlock) loadProductRuleConf(query url.Values) error {
+// LoadConfData load from config file.
+func (m *ModuleBlock) LoadConfData(query url.Values) error {
 	// get path
 	path := query.Get("path")
 	if path == "" {
@@ -246,7 +246,7 @@ func (m *ModuleBlock) monitorHandlers() map[string]interface{} {
 func (m *ModuleBlock) reloadHandlers() map[string]interface{} {
 	handlers := map[string]interface{}{
 		m.name + ".global_ip_table":    m.loadGlobalIPTable,
-		m.name + ".product_rule_table": m.loadProductRuleConf,
+		m.name + ".product_rule_table": m.LoadConfData,
 	}
 	return handlers
 }
@@ -270,8 +270,8 @@ func (m *ModuleBlock) Init(cbs *bfe_module.BfeCallbacks, whs *web_monitor.WebHan
 	if err = m.loadGlobalIPTable(nil); err != nil {
 		return fmt.Errorf("%s: loadGlobalIPTable() err %s", m.name, err.Error())
 	}
-	if err = m.loadProductRuleConf(nil); err != nil {
-		return fmt.Errorf("%s: loadProductRuleConf() err %s", m.name, err.Error())
+	if err = m.LoadConfData(nil); err != nil {
+		return fmt.Errorf("%s: LoadConfData() err %s", m.name, err.Error())
 	}
 
 	// register handler

--- a/bfe_modules/mod_cors/mod_cors_test.go
+++ b/bfe_modules/mod_cors/mod_cors_test.go
@@ -34,22 +34,22 @@ const (
 	expectProduct = "example_product"
 )
 
-func TestLoadRuleData(t *testing.T) {
+func TestLoadConfData(t *testing.T) {
 	m := NewModuleCors()
 
 	query := url.Values{
 		"path": []string{"testdata/mod_cors/cors_rule.data"},
 	}
 
-	expectModVersion := "cors_rule.data=20200508210000"
-	modVersion, err := m.loadRuleData(query)
+	//expectModVersion := "cors_rule.data=20200508210000"
+	 err := m.LoadConfData(query)
 	if err != nil {
 		t.Fatalf("should have no error, but error is %v", err)
 	}
 
-	if modVersion != expectModVersion {
-		t.Fatalf("version shoule be %s, but it's %s", expectModVersion, modVersion)
-	}
+	//if modVersion != expectModVersion {
+	//	t.Fatalf("version shoule be %s, but it's %s", expectModVersion, modVersion)
+	//}
 
 	expectVersion := "20200508210000"
 	if m.ruleTable.version != expectVersion {

--- a/bfe_modules/mod_doh/mod_doh.go
+++ b/bfe_modules/mod_doh/mod_doh.go
@@ -16,6 +16,7 @@ package mod_doh
 
 import (
 	"fmt"
+	"net/url"
 )
 
 import (
@@ -62,6 +63,10 @@ func NewModuleDoh() *ModuleDoh {
 
 func (m *ModuleDoh) Name() string {
 	return m.name
+}
+
+func (m *ModuleDoh) LoadConfData(query url.Values) error {
+	return nil
 }
 
 func (m *ModuleDoh) getState(params map[string][]string) ([]byte, error) {

--- a/bfe_modules/mod_errors/mod_errors.go
+++ b/bfe_modules/mod_errors/mod_errors.go
@@ -55,7 +55,7 @@ func (m *ModuleErrors) Name() string {
 	return m.name
 }
 
-func (m *ModuleErrors) loadConfData(query url.Values) error {
+func (m *ModuleErrors) LoadConfData(query url.Values) error {
 	// get file path
 	path := query.Get("path")
 	if path == "" {
@@ -111,8 +111,8 @@ func (m *ModuleErrors) Init(cbs *bfe_module.BfeCallbacks, whs *web_monitor.WebHa
 	m.configPath = cfg.Basic.DataPath
 
 	// load from config file to rule table
-	if err = m.loadConfData(nil); err != nil {
-		return fmt.Errorf("err in loadConfData(): %s", err.Error())
+	if err = m.LoadConfData(nil); err != nil {
+		return fmt.Errorf("err in LoadConfData(): %s", err.Error())
 	}
 
 	// register handler
@@ -122,9 +122,9 @@ func (m *ModuleErrors) Init(cbs *bfe_module.BfeCallbacks, whs *web_monitor.WebHa
 	}
 
 	// register web handler for reload
-	err = whs.RegisterHandler(web_monitor.WebHandleReload, m.name, m.loadConfData)
+	err = whs.RegisterHandler(web_monitor.WebHandleReload, m.name, m.LoadConfData)
 	if err != nil {
-		return fmt.Errorf("%s.Init(): RegisterHandler(m.loadConfData): %s", m.name, err.Error())
+		return fmt.Errorf("%s.Init(): RegisterHandler(m.LoadConfData): %s", m.name, err.Error())
 	}
 
 	return nil

--- a/bfe_modules/mod_geo/mod_geo.go
+++ b/bfe_modules/mod_geo/mod_geo.go
@@ -81,7 +81,7 @@ func (m *ModuleGeo) Name() string {
 	return m.name
 }
 
-func (m *ModuleGeo) loadConfData(query url.Values) error {
+func (m *ModuleGeo) LoadConfData(query url.Values) error {
 	// get file path
 	path := query.Get("path")
 	if path == "" {
@@ -189,7 +189,7 @@ func (m *ModuleGeo) Init(cbs *bfe_module.BfeCallbacks, whs *web_monitor.WebHandl
 	openDebug = conf.Log.OpenDebug
 
 	// read geolocation database
-	if err = m.loadConfData(nil); err != nil {
+	if err = m.LoadConfData(nil); err != nil {
 		return fmt.Errorf("%s: geolocation database load err %s", m.name, err.Error())
 	}
 
@@ -200,9 +200,9 @@ func (m *ModuleGeo) Init(cbs *bfe_module.BfeCallbacks, whs *web_monitor.WebHandl
 	}
 
 	// register web handler for reload
-	err = whs.RegisterHandler(web_monitor.WebHandleReload, m.name, m.loadConfData)
+	err = whs.RegisterHandler(web_monitor.WebHandleReload, m.name, m.LoadConfData)
 	if err != nil {
-		return fmt.Errorf("%s.Init(): RegisterHandler(m.loadConfData): %s", m.name, err.Error())
+		return fmt.Errorf("%s.Init(): RegisterHandler(m.LoadConfData): %s", m.name, err.Error())
 	}
 	// register web handler for monitor
 	err = whs.RegisterHandler(web_monitor.WebHandleMonitor, m.name, m.getState)

--- a/bfe_modules/mod_geo/mod_geo_test.go
+++ b/bfe_modules/mod_geo/mod_geo_test.go
@@ -50,7 +50,7 @@ func TestLoadModGeoConfigData(t *testing.T) {
 	m := NewModuleGeo()
 
 	// load conf data failed
-	err := m.loadConfData(url.Values{})
+	err := m.LoadConfData(url.Values{})
 	if err == nil {
 		t.Error("the return value of load mod_geo data is err, expect err")
 	}
@@ -60,7 +60,7 @@ func TestLoadModGeoConfigData(t *testing.T) {
 	testQuery.Add("path", "./test_data/mod_geo/geo.db")
 
 	// load conf data success
-	err = m.loadConfData(testQuery)
+	err = m.LoadConfData(testQuery)
 	if err != nil {
 		t.Errorf("load mod_geo conf data err: %s", err.Error())
 	}

--- a/bfe_modules/mod_header/mod_header.go
+++ b/bfe_modules/mod_header/mod_header.go
@@ -63,7 +63,7 @@ func (m *ModuleHeader) Name() string {
 	return m.name
 }
 
-func (m *ModuleHeader) loadConfData(query url.Values) error {
+func (m *ModuleHeader) LoadConfData(query url.Values) error {
 	// get file path
 	path := query.Get("path")
 	if path == "" {
@@ -179,8 +179,8 @@ func (m *ModuleHeader) init(cfg *ConfModHeader, cbs *bfe_module.BfeCallbacks,
 	m.disableDefaultHeader = cfg.Basic.DisableDefaultHeader
 
 	// load from config file to rule table
-	if err := m.loadConfData(nil); err != nil {
-		return fmt.Errorf("err in loadConfData(): %s", err.Error())
+	if err := m.LoadConfData(nil); err != nil {
+		return fmt.Errorf("err in LoadConfData(): %s", err.Error())
 	}
 
 	// register handler
@@ -196,9 +196,9 @@ func (m *ModuleHeader) init(cfg *ConfModHeader, cbs *bfe_module.BfeCallbacks,
 	}
 
 	// register web handler for reload
-	err = whs.RegisterHandler(web_monitor.WebHandleReload, m.name, m.loadConfData)
+	err = whs.RegisterHandler(web_monitor.WebHandleReload, m.name, m.LoadConfData)
 	if err != nil {
-		return fmt.Errorf("%s.Init(): RegisterHandler(m.loadConfData): %s", m.name, err.Error())
+		return fmt.Errorf("%s.Init(): RegisterHandler(m.LoadConfData): %s", m.name, err.Error())
 	}
 
 	return nil

--- a/bfe_modules/mod_http_code/mod_http_code.go
+++ b/bfe_modules/mod_http_code/mod_http_code.go
@@ -62,6 +62,10 @@ func (m *ModuleHttpCode) Name() string {
 	return m.name
 }
 
+func (m *ModuleHttpCode) LoadConfData(query url.Values) error {
+	return nil
+}
+
 func (m *ModuleHttpCode) getState(query url.Values) ([]byte, error) {
 	d := m.metrics.GetAll()
 	return d.Format(query)

--- a/bfe_modules/mod_key_log/mod_key_log.go
+++ b/bfe_modules/mod_key_log/mod_key_log.go
@@ -18,7 +18,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net/url"
-	"path/filepath"
 )
 
 import (
@@ -112,8 +111,8 @@ func (m *ModuleKeyLog) Init(cbs *bfe_module.BfeCallbacks, whs *web_monitor.WebHa
 	m.dataConfigPath = conf.Basic.DataPath
 
 	// load from data config file to rule table
-	if _, err := m.loadConfData(nil); err != nil {
-		return fmt.Errorf("err in loadConfData(): %s", err.Error())
+	if err := m.LoadConfData(nil); err != nil {
+		return fmt.Errorf("err in LoadConfData(): %s", err.Error())
 	}
 
 	// init logger
@@ -129,15 +128,15 @@ func (m *ModuleKeyLog) Init(cbs *bfe_module.BfeCallbacks, whs *web_monitor.WebHa
 	}
 
 	// register web handler for reload
-	err = whs.RegisterHandler(web_monitor.WebHandleReload, m.name, m.loadConfData)
+	err = whs.RegisterHandler(web_monitor.WebHandleReload, m.name, m.LoadConfData)
 	if err != nil {
-		return fmt.Errorf("%s.Init(): RegisterHandler(m.loadConfData): %s", m.name, err.Error())
+		return fmt.Errorf("%s.Init(): RegisterHandler(m.LoadConfData): %s", m.name, err.Error())
 	}
 
 	return nil
 }
 
-func (m *ModuleKeyLog) loadConfData(query url.Values) (string, error) {
+func (m *ModuleKeyLog) LoadConfData(query url.Values) error{
 	// get file path
 	path := query.Get("path")
 	if path == "" {
@@ -148,12 +147,12 @@ func (m *ModuleKeyLog) loadConfData(query url.Values) (string, error) {
 	// load from config file
 	conf, err := keyLogConfLoad(path)
 	if err != nil {
-		return "", fmt.Errorf("err in keyLogConfLoad(%s):%s", path, err.Error())
+		return fmt.Errorf("err in keyLogConfLoad(%s):%s", path, err.Error())
 	}
 
 	// update to rule table
 	m.ruleTable.Update(conf)
 
-	_, fileName := filepath.Split(path)
-	return fmt.Sprintf("%s=%s", fileName, conf.Version), nil
+	//_, fileName := filepath.Split(path)
+	return  nil
 }

--- a/bfe_modules/mod_logid/mod_logid.go
+++ b/bfe_modules/mod_logid/mod_logid.go
@@ -20,6 +20,7 @@ import (
 	"crypto/rand"
 	"encoding/hex"
 	"fmt"
+	"net/url"
 )
 
 import (
@@ -78,6 +79,10 @@ func (m *ModuleLogId) Init(cbs *bfe_module.BfeCallbacks, whs *web_monitor.WebHan
 		return fmt.Errorf("%s.Init(): RegisterHandler(m.getState): %s", m.name, err.Error())
 	}
 
+	return nil
+}
+
+func (m *ModuleLogId) LoadConfData(query url.Values) error {
 	return nil
 }
 

--- a/bfe_modules/mod_prison/mod_prison.go
+++ b/bfe_modules/mod_prison/mod_prison.go
@@ -18,7 +18,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"path/filepath"
 	"time"
 )
 
@@ -145,7 +144,7 @@ func (m *ModulePrison) getStateDiff(params map[string][]string) ([]byte, error) 
 	return s.Format(params)
 }
 
-func (m *ModulePrison) loadProductRuleTable(query url.Values) (string, error) {
+func (m *ModulePrison) LoadConfData(query url.Values) error {
 	// get reload file path
 	path := query.Get("path")
 	if path == "" {
@@ -155,15 +154,16 @@ func (m *ModulePrison) loadProductRuleTable(query url.Values) (string, error) {
 	// load and update rules
 	productConf, err := productRuleConfLoad(path)
 	if err != nil {
-		return "", fmt.Errorf("%s: load product rule err %s", m.name, err.Error())
+		return fmt.Errorf("%s: load product rule err %s", m.name, err.Error())
 	}
 	if err = m.productTable.load(productConf); err != nil {
-		return "", fmt.Errorf("%s: load prison err %s", m.name, err.Error())
+		return fmt.Errorf("%s: load prison err %s", m.name, err.Error())
 	}
 
-	version := *productConf.Version
-	_, fileName := filepath.Split(path)
-	return fmt.Sprintf("%s=%s", fileName, version), nil
+	//version := *productConf.Version
+	//_, fileName := filepath.Split(path)
+	//fmt.Sprintf("%s=%s", fileName, version),
+	return  nil
 }
 
 func (m *ModulePrison) monitorHandlers() map[string]interface{} {
@@ -186,8 +186,8 @@ func (m *ModulePrison) Init(cbs *bfe_module.BfeCallbacks, whs *web_monitor.WebHa
 	openDebug = conf.Log.OpenDebug
 
 	// load product rule table
-	if _, err := m.loadProductRuleTable(nil); err != nil {
-		return fmt.Errorf("%s.Init():loadProductRuleTable(): %s", m.name, err.Error())
+	if  err := m.LoadConfData(nil); err != nil {
+		return fmt.Errorf("%s.Init():LoadConfData(): %s", m.name, err.Error())
 	}
 
 	// register handler for prison
@@ -203,7 +203,7 @@ func (m *ModulePrison) Init(cbs *bfe_module.BfeCallbacks, whs *web_monitor.WebHa
 	}
 
 	// register web handler for reload
-	err = whs.RegisterHandler(web_monitor.WebHandleReload, m.name, m.loadProductRuleTable)
+	err = whs.RegisterHandler(web_monitor.WebHandleReload, m.name, m.LoadConfData)
 	if err != nil {
 		return fmt.Errorf("%s.Init():RegisterHandlers(m.reloadHandlers): %s", m.name, err.Error())
 	}

--- a/bfe_modules/mod_redirect/mod_redirect.go
+++ b/bfe_modules/mod_redirect/mod_redirect.go
@@ -17,7 +17,6 @@ package mod_redirect
 import (
 	"fmt"
 	"net/url"
-	"path/filepath"
 )
 
 import (
@@ -52,7 +51,7 @@ func (m *ModuleRedirect) Name() string {
 	return m.name
 }
 
-func (m *ModuleRedirect) loadConfData(query url.Values) (string, error) {
+func (m *ModuleRedirect) LoadConfData(query url.Values) error {
 	// get file path
 	path := query.Get("path")
 	if path == "" {
@@ -64,14 +63,15 @@ func (m *ModuleRedirect) loadConfData(query url.Values) (string, error) {
 	conf, err := redirectConfLoad(path)
 
 	if err != nil {
-		return "", fmt.Errorf("err in redirectConfLoad(%s):%s", path, err.Error())
+		return fmt.Errorf("err in redirectConfLoad(%s):%s", path, err.Error())
 	}
 
 	// update to rule table
 	m.ruleTable.Update(conf)
 
-	_, fileName := filepath.Split(path)
-	return fmt.Sprintf("%s=%s", fileName, conf.Version), nil
+	//_, fileName := filepath.Split(path)
+	//fmt.Sprintf("%s=%s", fileName, conf.Version),
+	return  nil
 }
 
 func redirectCodeSet(req *bfe_basic.Request, code int) {
@@ -146,8 +146,8 @@ func (m *ModuleRedirect) init(cfg *ConfModRedirect, cbs *bfe_module.BfeCallbacks
 	m.configPath = cfg.Basic.DataPath
 
 	// load from config file to rule table
-	if _, err := m.loadConfData(nil); err != nil {
-		return fmt.Errorf("err in loadConfData(): %s", err.Error())
+	if err := m.LoadConfData(nil); err != nil {
+		return fmt.Errorf("err in LoadConfData(): %s", err.Error())
 	}
 
 	// register handler
@@ -157,9 +157,9 @@ func (m *ModuleRedirect) init(cfg *ConfModRedirect, cbs *bfe_module.BfeCallbacks
 	}
 
 	// register web handler for reload
-	err = whs.RegisterHandler(web_monitor.WebHandleReload, m.name, m.loadConfData)
+	err = whs.RegisterHandler(web_monitor.WebHandleReload, m.name, m.LoadConfData)
 	if err != nil {
-		return fmt.Errorf("%s.Init(): RegisterHandler(m.loadConfData): %s", m.name, err.Error())
+		return fmt.Errorf("%s.Init(): RegisterHandler(m.LoadConfData): %s", m.name, err.Error())
 	}
 
 	return nil

--- a/bfe_modules/mod_rewrite/mod_rewrite.go
+++ b/bfe_modules/mod_rewrite/mod_rewrite.go
@@ -55,7 +55,7 @@ func (m *ModuleReWrite) Name() string {
 	return m.name
 }
 
-func (m *ModuleReWrite) loadConfData(query url.Values) error {
+func (m *ModuleReWrite) LoadConfData(query url.Values) error {
 	// get file path
 	path := query.Get("path")
 	if path == "" {
@@ -136,8 +136,8 @@ func (m *ModuleReWrite) init(cfg *ConfModReWrite, cbs *bfe_module.BfeCallbacks,
 	m.configPath = cfg.Basic.DataPath
 
 	// load from config file to rule table
-	if err := m.loadConfData(nil); err != nil {
-		return fmt.Errorf("err in loadConfData(): %s", err.Error())
+	if err := m.LoadConfData(nil); err != nil {
+		return fmt.Errorf("err in LoadConfData(): %s", err.Error())
 	}
 
 	// register handler
@@ -147,9 +147,9 @@ func (m *ModuleReWrite) init(cfg *ConfModReWrite, cbs *bfe_module.BfeCallbacks,
 	}
 
 	// register web handler for reload
-	err = whs.RegisterHandler(web_monitor.WebHandleReload, m.name, m.loadConfData)
+	err = whs.RegisterHandler(web_monitor.WebHandleReload, m.name, m.LoadConfData)
 	if err != nil {
-		return fmt.Errorf("%s.Init(): RegisterHandler(m.loadConfData): %s", m.name, err.Error())
+		return fmt.Errorf("%s.Init(): RegisterHandler(m.LoadConfData): %s", m.name, err.Error())
 	}
 
 	return nil

--- a/bfe_modules/mod_secure_link/mod_secure_link.go
+++ b/bfe_modules/mod_secure_link/mod_secure_link.go
@@ -81,8 +81,8 @@ func (m *ModuleSecureLink) Init(cbs *bfe_module.BfeCallbacks, whs *web_monitor.W
 
 	m.configPath = cfg.Basic.DataPath
 	// load from config file to rule table
-	if err := m.loadConfData(nil); err != nil {
-		return fmt.Errorf("err in loadConfData(): %s", err.Error())
+	if err := m.LoadConfData(nil); err != nil {
+		return fmt.Errorf("err in LoadConfData(): %s", err.Error())
 	}
 
 	// register handler
@@ -92,9 +92,9 @@ func (m *ModuleSecureLink) Init(cbs *bfe_module.BfeCallbacks, whs *web_monitor.W
 	}
 
 	// register web handler for reload
-	err = whs.RegisterHandler(web_monitor.WebHandleReload, m.name, m.loadConfData)
+	err = whs.RegisterHandler(web_monitor.WebHandleReload, m.name, m.LoadConfData)
 	if err != nil {
-		return fmt.Errorf("%s.Init(): RegisterHandler(m.loadConfData): %s", m.name, err.Error())
+		return fmt.Errorf("%s.Init(): RegisterHandler(m.LoadConfData): %s", m.name, err.Error())
 	}
 
 	return nil
@@ -138,7 +138,7 @@ func (m *ModuleSecureLink) validateHandler(request *bfe_basic.Request) (int, *bf
 	return bfe_module.BfeHandlerGoOn, nil
 }
 
-func (m *ModuleSecureLink) loadConfData(query url.Values) error {
+func (m *ModuleSecureLink) LoadConfData(query url.Values) error {
 	// get file path
 	path := query.Get("path")
 	if path == "" {

--- a/bfe_modules/mod_secure_link/mod_secure_link_test.go
+++ b/bfe_modules/mod_secure_link/mod_secure_link_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestModuleSecureLink(t *testing.T) {
 	mod := NewModuleSecureLink()
-	err := mod.loadConfData(url.Values{
+	err := mod.LoadConfData(url.Values{
 		"path": {"testdata/mod_secure_link/secure_link_rule.data"},
 	})
 	if err != nil {

--- a/bfe_modules/mod_static/mod_static.go
+++ b/bfe_modules/mod_static/mod_static.go
@@ -54,6 +54,7 @@ type ModuleStaticState struct {
 
 type ModuleStatic struct {
 	name          string
+	configPath    string
 	state         ModuleStaticState
 	metrics       metrics.Metrics
 	conf          *ConfModStatic
@@ -74,10 +75,10 @@ func (m *ModuleStatic) Name() string {
 	return m.name
 }
 
-func (m *ModuleStatic) loadConfData(query url.Values) error {
+func (m *ModuleStatic) LoadConfData(query url.Values) error {
 	path := query.Get("path")
 	if path == "" {
-		path = m.conf.Basic.DataPath
+		path = m.configPath
 	}
 
 	conf, err := StaticConfLoad(path)
@@ -125,7 +126,7 @@ func (m *ModuleStatic) monitorHandlers() map[string]interface{} {
 
 func (m *ModuleStatic) reloadHandlers() map[string]interface{} {
 	handlers := map[string]interface{}{
-		m.name:                              m.loadConfData,
+		m.name:                              m.LoadConfData,
 		fmt.Sprintf("%s.mime_type", m.name): m.loadMimeType,
 	}
 	return handlers
@@ -278,9 +279,9 @@ func (m *ModuleStatic) Init(cbs *bfe_module.BfeCallbacks, whs *web_monitor.WebHa
 	}
 	openDebug = cfg.Log.OpenDebug
 	m.conf = cfg
-
-	if err = m.loadConfData(nil); err != nil {
-		return fmt.Errorf("err in loadConfData(): %v", err)
+	m.configPath = cfg.Basic.DataPath
+	if err = m.LoadConfData(nil); err != nil {
+		return fmt.Errorf("err in LoadConfData(): %v", err)
 	}
 
 	if err = m.loadMimeType(nil); err != nil {

--- a/bfe_modules/mod_tag/mod_tag.go
+++ b/bfe_modules/mod_tag/mod_tag.go
@@ -17,7 +17,6 @@ package mod_tag
 import (
 	"fmt"
 	"net/url"
-	"path/filepath"
 )
 
 import (
@@ -56,7 +55,7 @@ func (m *ModuleTag) Name() string {
 	return m.name
 }
 
-func (m *ModuleTag) loadRuleData(query url.Values) (string, error) {
+func (m *ModuleTag) LoadConfData(query url.Values) error {
 	// get file path
 	path := query.Get("path")
 	if path == "" {
@@ -67,14 +66,15 @@ func (m *ModuleTag) loadRuleData(query url.Values) (string, error) {
 	// load from config file
 	conf, err := TagRuleFileLoad(path)
 	if err != nil {
-		return "", fmt.Errorf("%s: TagRuleFileLoad(%s) error: %v", m.name, path, err)
+		return fmt.Errorf("%s: TagRuleFileLoad(%s) error: %v", m.name, path, err)
 	}
 
 	// update to rule table
 	m.ruleTable.Update(conf)
 
-	_, fileName := filepath.Split(path)
-	return fmt.Sprintf("%s=%s", fileName, conf.Version), nil
+	//_, fileName := filepath.Split(path)
+	//return fmt.Sprintf("%s=%s", fileName, conf.Version), nil
+	return   nil
 }
 
 func (m *ModuleTag) tagHandler(request *bfe_basic.Request) (int, *bfe_http.Response) {
@@ -100,15 +100,14 @@ func (m *ModuleTag) tagHandler(request *bfe_basic.Request) (int, *bfe_http.Respo
 
 func (m *ModuleTag) reloadHandlers() map[string]interface{} {
 	handlers := map[string]interface{}{
-		m.name: m.loadRuleData,
+		m.name: m.LoadConfData,
 	}
 	return handlers
 }
 
 func (m *ModuleTag) init(conf *ConfModTag, cbs *bfe_module.BfeCallbacks, whs *web_monitor.WebHandlers) error {
 	var err error
-
-	_, err = m.loadRuleData(nil)
+	err = m.LoadConfData(nil)
 	if err != nil {
 		return err
 	}

--- a/bfe_modules/mod_tag/mod_tag_test.go
+++ b/bfe_modules/mod_tag/mod_tag_test.go
@@ -33,7 +33,7 @@ const (
 	expectProduct = "example_product"
 )
 
-func TestLoadRuleData(t *testing.T) {
+func TestLoadConfData(t *testing.T) {
 	m := new(ModuleTag)
 	m.ruleTable = new(TagRuleTable)
 
@@ -41,15 +41,13 @@ func TestLoadRuleData(t *testing.T) {
 		"path": []string{"testdata/mod_tag/tag_rule.data"},
 	}
 
-	expectModVersion := "tag_rule.data=20200218210000"
-	modVersion, err := m.loadRuleData(query)
+	//expectModVersion := "tag_rule.data=20200218210000"
+    err := m.LoadConfData(query)
 	if err != nil {
 		t.Fatalf("should have no error, but error is %v", err)
 	}
 
-	if modVersion != expectModVersion {
-		t.Fatalf("version shoule be %s, but it's %s", expectModVersion, modVersion)
-	}
+
 
 	expectVersion := "20200218210000"
 	if m.ruleTable.version != expectVersion {
@@ -121,7 +119,7 @@ func TestTagHandlerCase2(t *testing.T) {
 	m.ruleTable = new(TagRuleTable)
 
 	query := url.Values{"path": []string{"testdata/mod_tag/tag_rule.data3"}}
-	_, err := m.loadRuleData(query)
+	err := m.LoadConfData(query)
 	if err != nil {
 		t.Fatalf("should have no error, but error is %v", err)
 	}
@@ -160,7 +158,7 @@ func TestTagHandlerCase3(t *testing.T) {
 	m.ruleTable = new(TagRuleTable)
 
 	query := url.Values{"path": []string{"testdata/mod_tag/tag_rule.data4"}}
-	_, err := m.loadRuleData(query)
+	err := m.LoadConfData(query)
 	if err != nil {
 		t.Fatalf("should have no error, but error is %v", err)
 	}

--- a/bfe_modules/mod_trace/mod_trace.go
+++ b/bfe_modules/mod_trace/mod_trace.go
@@ -17,7 +17,6 @@ package mod_trace
 import (
 	"fmt"
 	"net/url"
-	"path/filepath"
 	"strings"
 )
 
@@ -75,7 +74,7 @@ func (m *ModuleTrace) Name() string {
 	return m.name
 }
 
-func (m *ModuleTrace) loadRuleData(query url.Values) (string, error) {
+func (m *ModuleTrace) LoadConfData(query url.Values) error {
 	// get file path
 	path := query.Get("path")
 	if path == "" {
@@ -86,14 +85,15 @@ func (m *ModuleTrace) loadRuleData(query url.Values) (string, error) {
 	// load from config file
 	conf, err := TraceRuleFileLoad(path)
 	if err != nil {
-		return "", fmt.Errorf("%s: TraceRuleFileLoad(%s) error: %v", m.name, path, err)
+		return   fmt.Errorf("%s: TraceRuleFileLoad(%s) error: %v", m.name, path, err)
 	}
 
 	// update to rule table
 	m.ruleTable.Update(conf)
 
-	_, fileName := filepath.Split(path)
-	return fmt.Sprintf("%s=%s", fileName, conf.Version), nil
+	//_, fileName := filepath.Split(path)
+	//fmt.Sprintf("%s=%s", fileName, conf.Version),
+	return  nil
 }
 
 func (m *ModuleTrace) startTrace(request *bfe_basic.Request) (int, *bfe_http.Response) {
@@ -188,7 +188,7 @@ func (m *ModuleTrace) monitorHandlers() map[string]interface{} {
 
 func (m *ModuleTrace) reloadHandlers() map[string]interface{} {
 	handlers := map[string]interface{}{
-		m.name: m.loadRuleData,
+		m.name: m.LoadConfData,
 	}
 	return handlers
 }
@@ -201,7 +201,7 @@ func (m *ModuleTrace) init(conf *ConfModTrace, cbs *bfe_module.BfeCallbacks, whs
 		return err
 	}
 
-	_, err = m.loadRuleData(nil)
+	err = m.LoadConfData(nil)
 	if err != nil {
 		return err
 	}

--- a/bfe_modules/mod_trace/mod_trace_test.go
+++ b/bfe_modules/mod_trace/mod_trace_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/bfenetworks/bfe/bfe_module"
 )
 
-func TestLoadRuleData(t *testing.T) {
+func TestLoadConfData(t *testing.T) {
 	m := new(ModuleTrace)
 	m.ruleTable = new(TraceRuleTable)
 
@@ -37,15 +37,15 @@ func TestLoadRuleData(t *testing.T) {
 		"path": []string{"testdata/mod_trace/trace_rule.data"},
 	}
 
-	expectModVersion := "trace_rule.data=20200316215500"
-	modVersion, err := m.loadRuleData(query)
+	//expectModVersion := "trace_rule.data=20200316215500"
+	 err := m.LoadConfData(query)
 	if err != nil {
 		t.Fatalf("should have no error, but error is %v", err)
 	}
 
-	if modVersion != expectModVersion {
-		t.Fatalf("version shoule be %s, but it's %s", expectModVersion, modVersion)
-	}
+	//if modVersion != expectModVersion {
+	//	t.Fatalf("version shoule be %s, but it's %s", expectModVersion, modVersion)
+	//}
 
 	expectVersion := "20200316215500"
 	if m.ruleTable.version != expectVersion {

--- a/bfe_modules/mod_trust_clientip/mod_trust_clientip.go
+++ b/bfe_modules/mod_trust_clientip/mod_trust_clientip.go
@@ -119,7 +119,7 @@ func ipItemsMake(conf TrustIPConf) (*ipdict.IPItems, error) {
 	return ipItems, nil
 }
 
-func (m *ModuleTrustClientIP) loadConfData(query url.Values) error {
+func (m *ModuleTrustClientIP) LoadConfData(query url.Values) error {
 	// get file path
 	path := query.Get("path")
 	if path == "" {
@@ -212,8 +212,8 @@ func (m *ModuleTrustClientIP) init(cfg *ConfModTrustClientIP, cbs *bfe_module.Bf
 	m.trustTable = ipdict.NewIPTable()
 
 	// load from config file to trust-table
-	if err := m.loadConfData(nil); err != nil {
-		return fmt.Errorf("err in loadConfData(): %s", err.Error())
+	if err := m.LoadConfData(nil); err != nil {
+		return fmt.Errorf("err in LoadConfData(): %s", err.Error())
 	}
 
 	// register handler
@@ -230,9 +230,9 @@ func (m *ModuleTrustClientIP) init(cfg *ConfModTrustClientIP, cbs *bfe_module.Bf
 	}
 
 	// register web handler for reload
-	err = whs.RegisterHandler(web_monitor.WebHandleReload, m.name, m.loadConfData)
+	err = whs.RegisterHandler(web_monitor.WebHandleReload, m.name, m.LoadConfData)
 	if err != nil {
-		return fmt.Errorf("%s.Init(): RegisterHandler(m.loadConfData): %s", m.name, err.Error())
+		return fmt.Errorf("%s.Init(): RegisterHandler(m.LoadConfData): %s", m.name, err.Error())
 	}
 
 	return nil

--- a/bfe_modules/mod_trust_clientip/mod_trust_clientip_test.go
+++ b/bfe_modules/mod_trust_clientip/mod_trust_clientip_test.go
@@ -33,9 +33,9 @@ func TestAcceptHandler_1(t *testing.T) {
 
 	// load conf from file
 	m.configPath = "./testdata/trust_ip_1.conf"
-	err = m.loadConfData(nil)
+	err = m.LoadConfData(nil)
 	if err != nil {
-		t.Errorf("get err from m.loadConfData():%s", err.Error())
+		t.Errorf("get err from m.LoadConfData():%s", err.Error())
 		return
 	}
 

--- a/bfe_modules/mod_userid/conf_mod_userid.go
+++ b/bfe_modules/mod_userid/conf_mod_userid.go
@@ -34,12 +34,12 @@ type ConfModUserID struct {
 }
 
 func ConfLoad(filePath, confRoot string) (*ConfModUserID, error) {
-	var cfg ConfModUserID
+	cfg:= &ConfModUserID{}
 
 	// read config from file
-	err := gcfg.ReadFileInto(&cfg, filePath)
+	err := gcfg.ReadFileInto(cfg, filePath)
 	if err != nil {
-		return &cfg, err
+		return nil, err
 	}
 
 	if cfg.Basic.DataPath == "" {
@@ -49,5 +49,5 @@ func ConfLoad(filePath, confRoot string) (*ConfModUserID, error) {
 
 	cfg.Basic.DataPath = bfe_util.ConfPathProc(cfg.Basic.DataPath, confRoot)
 
-	return &cfg, nil
+	return cfg, nil
 }

--- a/bfe_modules/mod_userid/conf_mod_userid.go
+++ b/bfe_modules/mod_userid/conf_mod_userid.go
@@ -34,12 +34,12 @@ type ConfModUserID struct {
 }
 
 func ConfLoad(filePath, confRoot string) (*ConfModUserID, error) {
-	cfg := &ConfModUserID{}
+	var cfg ConfModUserID
 
 	// read config from file
-	err := gcfg.ReadFileInto(cfg, filePath)
+	err := gcfg.ReadFileInto(&cfg, filePath)
 	if err != nil {
-		return nil, err
+		return &cfg, err
 	}
 
 	if cfg.Basic.DataPath == "" {
@@ -49,5 +49,5 @@ func ConfLoad(filePath, confRoot string) (*ConfModUserID, error) {
 
 	cfg.Basic.DataPath = bfe_util.ConfPathProc(cfg.Basic.DataPath, confRoot)
 
-	return cfg, nil
+	return &cfg, nil
 }

--- a/bfe_modules/mod_userid/mod_userid.go
+++ b/bfe_modules/mod_userid/mod_userid.go
@@ -21,7 +21,6 @@ import (
 	"fmt"
 	"math/rand"
 	"net/url"
-	"path/filepath"
 	"sync"
 	"time"
 )
@@ -70,13 +69,13 @@ func (m *ModuleUserID) Init(cbs *bfe_module.BfeCallbacks, whs *web_monitor.WebHa
 
 	openDebug = cfg.Log.OpenDebug
 	m.confFile = cfg.Basic.DataPath
-	if _, err := m.loadConfData(nil); err != nil {
+	if err := m.LoadConfData(nil); err != nil {
 		return fmt.Errorf("%s: conf load err %v", m.name, err)
 	}
 
 	// register handlers
-	if err := whs.RegisterHandler(web_monitor.WebHandleReload, m.name, m.loadConfData); err != nil {
-		return fmt.Errorf("%s.Init(): RegisterHandler(m.loadConfData): %s", m.name, err.Error())
+	if err := whs.RegisterHandler(web_monitor.WebHandleReload, m.name, m.LoadConfData); err != nil {
+		return fmt.Errorf("%s.Init(): RegisterHandler(m.LoadConfData): %s", m.name, err.Error())
 	}
 
 	if err := cbs.AddFilter(bfe_module.HandleFoundProduct, m.reqSetUid); err != nil {
@@ -90,21 +89,20 @@ func (m *ModuleUserID) Init(cbs *bfe_module.BfeCallbacks, whs *web_monitor.WebHa
 	return nil
 }
 
-func (m *ModuleUserID) loadConfData(query url.Values) (string, error) {
-	path := m.confFile
-	if q := query.Get("path"); q != "" {
-		path = q
+func (m *ModuleUserID) LoadConfData(query url.Values) error{
+	path := query.Get("path")
+	if path == "" {
+		// use default
+		path = m.confFile
 	}
 
 	config, err := NewConfigFromFile(path)
 	if err != nil {
-		return "", err
+		return err
 	}
 
 	m.setConfig(config)
-
-	_, fileName := filepath.Split(path)
-	return fmt.Sprintf("%s=%s", fileName, config.Version), nil
+	return nil
 }
 
 func (m *ModuleUserID) setConfig(config *Config) {

--- a/bfe_modules/mod_userid/mod_userid_test.go
+++ b/bfe_modules/mod_userid/mod_userid_test.go
@@ -39,7 +39,7 @@ func TestModuleUserIDName(t *testing.T) {
 
 func modFactory() *ModuleUserID {
 	m := NewModuleUserID()
-	m.loadConfData(url.Values{
+	m.LoadConfData(url.Values{
 		"path": []string{"./testdata/mod_userid/userid_rule.data"},
 	})
 	return m

--- a/bfe_modules/mod_waf/mod_waf_test.go
+++ b/bfe_modules/mod_waf/mod_waf_test.go
@@ -68,7 +68,7 @@ func TestModuleWafHandleWaf(t *testing.T) {
 	}
 
 	queryV := map[string][]string{"path": {"./testdata/mod_waf/waf_rule_check.data"}}
-	err := mw.loadProductRuleConf(queryV)
+	err := mw.LoadConfData(queryV)
 	if err != nil {
 		t.Errorf("reload waf rule err=%s", err)
 		t.FailNow()

--- a/conf/bfe.conf
+++ b/conf/bfe.conf
@@ -52,12 +52,25 @@ Modules = mod_redirect
 Modules = mod_logid
 Modules = mod_tag
 Modules = mod_trace
-#Modules = mod_userid
-#Modules = mod_key_log
+Modules = mod_userid
+Modules = mod_key_log
 Modules = mod_access
 Modules = mod_prison
-#Modules = mod_auth_request
-# Modules = mod_cors
+Modules = mod_auth_request
+Modules = mod_cors
+
+Modules = mod_auth_basic
+Modules = mod_auth_jwt
+Modules = mod_compress
+Modules = mod_doh
+Modules = mod_errors
+#Modules = mod_geo
+Modules = mod_markdown
+Modules = mod_redirect
+Modules = mod_static
+Modules = mod_waf
+Modules = mod_http_code
+#Modules = mod_secure_link
 
 # interval for get diff of proxy-state
 MonitorInterval = 20

--- a/conf/mod_auth_basic/auth_basic_rule.data
+++ b/conf/mod_auth_basic/auth_basic_rule.data
@@ -3,7 +3,7 @@
         "example_product": [
             {
                 "Cond": "req_host_in(\"www.example.org\")",
-                "UserFile": "../conf/mod_auth_basic/userfile",
+                "UserFile": "./conf/mod_auth_basic/userfile",
                 "Realm": "example_product"
             }
         ]

--- a/conf/mod_auth_jwt/auth_jwt_rule.data
+++ b/conf/mod_auth_jwt/auth_jwt_rule.data
@@ -3,7 +3,7 @@
         "example_product": [
             {
                 "Cond": "req_host_in(\"www.example.org\")",
-                "KeyFile": "../conf/mod_auth_jwt/key_file",
+                "KeyFile": "./conf/mod_auth_jwt/key_file",
                 "Realm": "example_product"
             }
         ]

--- a/conf/mod_errors/errors_rule.data
+++ b/conf/mod_errors/errors_rule.data
@@ -8,7 +8,7 @@
                     {
                         "Cmd": "RETURN",
                         "Params": [
-                            "200", "text/html", "../conf/mod_errors/404.html"
+                            "200", "text/html", "./conf/mod_errors/404.html"
                         ]
                     }
                 ]

--- a/conf/mod_key_log/mod_key_log.conf
+++ b/conf/mod_key_log/mod_key_log.conf
@@ -4,4 +4,4 @@ LogDir = ../log
 RotateWhen = MIDNIGHT
 BackupCount = 3
 [basic]
-DataPath = mod_key_log/key_log.data
+DataPath = ./conf/mod_key_log/key_log.data

--- a/conf/mod_static/static_rule.data
+++ b/conf/mod_static/static_rule.data
@@ -6,7 +6,7 @@
                 "Action": {
                     "Cmd": "BROWSE",
                     "Params": [
-                        "../conf/mod_static",
+                        "./conf/mod_static",
                         "index.html"
                     ]
                 }

--- a/conf/mod_trust_clientip/trust_client_ip.data
+++ b/conf/mod_trust_clientip/trust_client_ip.data
@@ -1,9 +1,9 @@
 {
-    "Version": "init version",
+    "Version": "one version",
     "Config": {
         "inner-idc": [
             {
-                "Begin": "10.0.0.0",
+                "Begin": "10.0.10.8",
                 "End": "10.255.255.255"
             }
         ]

--- a/conf/mod_userid/userid_rule.data
+++ b/conf/mod_userid/userid_rule.data
@@ -1,5 +1,5 @@
 {
-    "Version": "2019-12-10184356",
+    "Version": "2021-12-10184356",
     "Config": {
         "example_product": [
             {


### PR DESCRIPTION
初步尝试的一个设计方案 ，是我针对bfe 能够通过sighub对相关配置重载功能的解决思路，不太明确的相关修改是否会对现有的功能产生冲突，存在不合理的地方，我在这个版本上再修改。

下面是我对相关功能修改的一个说明 ，主要是在BfeModule 模块当中统一添加了LoadConfData这样一个模块接口，其他的模块均统一实现这个定义的接口，这里存在一个冲突的地方是 ，有些moudle 里面，相关的LoadConf 函数的返回值 返回了两个参数，当前全部修改成了第一种方式，相关的测试函数也改成了第一种方式，不知BFE 的设计更加适合那种方式。
```
// Load module conf
LoadConfData(query url.Values) error

LoadConfData(query url.Values) (string,error)
```
然后这个目前仅仅是针对conf 目录下 mod模块的配置文件的一个更新，bfe.conf 没有支持，是否还需要对其他的配置也需要实现通过sighub 来更新的对应配置文件的功能。

同时这个功能的实现需要在bfe.conf 里面填写对应的配置，例如 Modules = mod_auth_basic，才能在配置文件修改之后，运行 kill -s SIGHUB BFEpid，程序运行时对应的配置参数才会生效，目前 bfe.conf 里面只涉及到部分Moudles 的注册，有无必要如同我对bfe.conf 里面的修改添加其他的Modules 。

目前我是在goland 的debug模式下测试的，所以对之前没有在bfe.conf 里面的注册一些模块的相关配置路径修改了一下。bfe 在编译成功之后，会有一个专门的配置文件目录，这种模式下在我仅仅只部署bfe的情况下，目前观察不到程序中对应的配置是否发生了改变，还不太明确这个配置路径的修改是否会影响编译之后的配置读取。