### PR TITLE
Improve and fix error in cluster_conf.data.md (issue #833)

### DIFF
--- a/docs/en_us/configuration/server_data_conf/cluster_conf.data.md
+++ b/docs/en_us/configuration/server_data_conf/cluster_conf.data.md
@@ -44,8 +44,8 @@ CheckConf is config of backend check.
 | Uri           | String<br>Uri used in health check (HTTP only). Default value is "/health_check". |
 | Host          | String<br>Host used in health check (HTTP only). Default value is "". |
 | StatusCode    | Int<br>Expected response code (HTTP only). Default value is 200. And 0 means any response code is considered expected. |
-| FailNum       | Int<br>Failure threshold (consecutive failures of forwarded requests ), which will trigger BFE to set backend instance as failed state and start health check. |
-| SuccNum       | Int<br>Healthy threshold (consecutive successes of health check request), which will trigger BFE to set backend instance as healthy state and stop health check. |
+| FailNum       | Int<br>Failure threshold (consecutive failures of forwarded requests ), which will trigger BFE to set backend instance to unavailable state and start the health check. |
+| SuccNum       | Int<br>Healthy threshold (consecutive successes of health check request), which will trigger BFE to set backend instance to available state and stop the health check. |
 | CheckTimeout  | Int<br>Timeout for health check, in ms. Default value is 0, which means no timeout. |
 | CheckInterval | Int<br>Interval of health check, in ms. Default value is 1000. |
 

--- a/docs/en_us/configuration/server_data_conf/cluster_conf.data.md
+++ b/docs/en_us/configuration/server_data_conf/cluster_conf.data.md
@@ -23,16 +23,16 @@ BackendConf is config for backend.
 
 | Config Item           | Description                                 |
 | --------------------- | ------------------------------------------- |
-| Protocol              | String<br>Protocol for connecting backend, http and fcgi are supported. Default value is http |
-| TimeoutConnSrv        | Int<br>Timeout for connecting backend, in ms. Default value is 2000 |
-| TimeoutResponseHeader | Int<br>Timeout for reading response header, in ms. Default value is 60000 |
+| Protocol              | String<br>Protocol for connecting backend. http and fcgi are supported. Default value is http. |
+| TimeoutConnSrv        | Int<br>Timeout for connecting backend, in ms. Default value is 2000. |
+| TimeoutResponseHeader | Int<br>Timeout for reading response header, in ms. Default value is 60000. |
 | MaxIdleConnsPerHost   | Int<br>Max idle connections to each backend per BFE. Default value is 2. |
 | MaxConnsPerHost   | Int<br>Max number of concurrent connections to each backend per BFE. 0 means no limitation. Default value is 0. |
 | RetryLevel            | Int<br>Retry level if request fail. 0: retry after connecting backend fails; 1: retry after connecting backend fails or forwarding GET request fails. Default value is 0. |
-| BackendConf.OutlierDetectionHttpCode            | String<br>Backend HTTP status code status detection. <br>"" means disable detection, "500" means "500" is considered as backend failure and increase counter by 1. <br>Status code use format "[0-9]{3}"(e.g "500"); multiple status codes are seperated by "\|".<br>Default value is "", means disable detection. |
+| BackendConf.OutlierDetectionHttpCode            | String<br>Backend HTTP status code status detection. <br>"" means disable detection, "500" means "500" is considered as backend failure. <br>Status code uses format "[0-9]{3}"(e.g "500"). Multiple status codes are seperated by "\|".<br>Default value is "", which means disable the detection. |
 | FCGIConf              | Object<br>Conf for FastCGI Protocol                |
-| FCGIConf.Root         | String<br>the root folder of the website       |
-| FCGIConf.EnvVars      | Map[string]string<br>extra environment variable    |
+| FCGIConf.Root         | String<br>The root folder of the website       |
+| FCGIConf.EnvVars      | Map[string]string<br>Extra environment variable    |
 
 #### Health Check Config
 
@@ -44,8 +44,8 @@ CheckConf is config of backend check.
 | Uri           | String<br>Uri used in health check (HTTP only). Default value is "/health_check". |
 | Host          | String<br>Host used in health check (HTTP only). Default value is "". |
 | StatusCode    | Int<br>Expected response code (HTTP only). Default value is 200. And 0 means any response code is considered valid. |
-| FailNum       | Int<br>Failure threshold (consecutive failures of forwarded requests ), which will trigger BFE to set backend instance to unavailable state and start the health check. |
-| SuccNum       | Int<br>Healthy threshold (consecutive successes of health check request), which will trigger BFE to set backend instance to available state and stop the health check. |
+| FailNum       | Int<br>Failure threshold (consecutive failures of forwarded requests), which will trigger BFE to set the backend instance to unavailable state and start the health check. |
+| SuccNum       | Int<br>Healthy threshold (consecutive successes of health check request), which will trigger BFE to set the backend instance to available state and stop the health check. |
 | CheckTimeout  | Int<br>Timeout for health check, in ms. Default value is 0, which means no timeout. |
 | CheckInterval | Int<br>Interval of health check, in ms. Default value is 1000. |
 
@@ -59,7 +59,7 @@ GslbBasic is cluster config for Gslb.
 | RetryMax              | Int<br>Max retry times within same sub-cluster. Default value is 2. |
 | BalanceMode           | String<br>Load Balance Mode. Supported mode: WRR(Weighted Round Robin), WLC(Weighted Least Connection). Default value is WRR. |
 | HashConf              | Struct<br>Hash config of session persistence<br>             |
-| HashConf.HashStrategy | Int<br>Hash Strategy of session persistence. Supported strategy: 0: ClientIdOnly, 1: ClientIpOnly, 2: ClientIdPreferred, 3: RequestURI. Default value is 1 (ClientIpOnly).<br> |
+| HashConf.HashStrategy | Int<br>Hash Strategy of session persistence. Supported strategies: 0: ClientIdOnly, 1: ClientIpOnly, 2: ClientIdPreferred, 3: RequestURI. Default value is 1 (ClientIpOnly).<br> |
 | HashConf.HashHeader   | String<br>HashHeader is an optional request header which represents a unique client. Format for speicial cookie header is "Cookie:Key"<br> |
 | HashConf.SessonSticky | Boolean<br>Set SessionSticky to "true" enable sticky session (ensures that all requests from the user during the session are sent to the same backend). If set to "false", the session persistence will be at sub-cluster level. |
 

--- a/docs/en_us/configuration/server_data_conf/cluster_conf.data.md
+++ b/docs/en_us/configuration/server_data_conf/cluster_conf.data.md
@@ -6,12 +6,16 @@ cluster_conf.data records the cluster config.
 
 ## Configuration
 
-| Config Item | Description                                                   |
-| ----------- | ------------------------------------------------------------- |
-| Version     | String<br>Verson of config file                                         |
+| Config Item | Description                                                  |
+| ----------- | ------------------------------------------------------------ |
+| Version     | String<br>Version of config file                             |
 | Config      | Struct<br>Map data, key is cluster name, value is cluster config detail |
+| Config[k]   | String<br>Cluster name                                       |
+| Config[v]   | Object<br>Cluster's routing config                           |
 
 ### Cluster Config Detail
+
+Notice: below config are in namespace Config[v].
 
 #### Backend Config
 
@@ -19,42 +23,45 @@ BackendConf is config for backend.
 
 | Config Item           | Description                                 |
 | --------------------- | ------------------------------------------- |
-| Protocol              | String<br>Protocol for conect backend, supported http and fcgi, default is http |
-| TimeoutConnSrv        | Int<br>Timeout for connect backend, in ms          |
-| TimeoutResponseHeader | Int<br>Timeout for read response header, in ms     |
-| MaxIdleConnsPerHost   | Int<br>Max idle conns to each backend              |
-| MaxConnsPerHost   | Int<br>Max number of concurrent conns to each backend              |
-| RetryLevel            | Int<br>Retry level if request fail                 |
-| BackendConf.OutlierDetectionHttpCode            | String<br> Http status code that represent error status of backend |
+| Protocol              | String<br>Protocol for connect backend, support http and fcgi. Default value is http |
+| TimeoutConnSrv        | Int<br>Timeout for connect backend, in ms. Default value is 2000 |
+| TimeoutResponseHeader | Int<br>Timeout for read response header, in ms. Default value is 60000 |
+| MaxIdleConnsPerHost   | Int<br>Max idle connections to each backend per BFE. Default value is 2. |
+| MaxConnsPerHost   | Int<br>Max number of concurrent connections to each backend per BFE. 0 means no limitation. Default value is 0. |
+| RetryLevel            | Int<br>Retry level if request fail. 0: retry after connect backend fails; 1: retry after connect backend fails or forwarding GET request fails. Default value is 0. |
+| BackendConf.OutlierDetectionHttpCode            | String<br>Backend HTTP status code status detection. <br>"" means disable detection, "500" means consider "500" as backend failure and increase counter by 1. <br>Status code use format "dxx"(e.g "500"); separate multiple status code by "\|".<br>Default value is "", means disable detection. |
 | FCGIConf              | Object<br>Conf for FastCGI Protocol                |
-| FCGIConf.Root         | String<br>the root folder to the site              |
+| FCGIConf.Root         | String<br>the root folder of the website       |
 | FCGIConf.EnvVars      | Map[string]string<br>extra environment variable    |
 
 #### Health Check Config
 
 CheckConf is config of backend check.
 
-| Config Item   | Description                                                 |
-| ------------- | ----------------------------------------------------------- |
-| Schem         | String<br>Protocol for health check (HTTP/TCP)                        |
-| Uri           | String<br>Uri used in health check (HTTP)                             |
-| Host          | String<br>If check request use special host header (HTTP)             |
-| StatusCode    | Int<br>Expected response code, default value is 200 (HTTP)         |
-| FailNum       | Int<br>Unhealthy threshold (consecutive failures of check request) |
-| SuccNum       | Int<br>Healthy threshold (consecutive successes of normal request) |
-| CheckTimeout  | Int<br>Timeout for health check, in ms                             |
-| CheckInterval | Int<br>Interval of health check, in ms                             |
+| Config Item   | Description                                                  |
+| ------------- | ------------------------------------------------------------ |
+| Schem         | String<br>Protocol for health check (HTTP/TCP). Default value is http. |
+| Uri           | String<br>Uri used in health check (HTTP only). Default value is "/health_check". |
+| Host          | String<br>Host used in health check (HTTP only). Default value is "". |
+| StatusCode    | Int<br>Expected response code (HTTP only). Default value is 200. And 0 means any response code is considered expected. |
+| FailNum       | Int<br>Failure threshold (consecutive failures of forwarded requests ), which will trigger BFE to set backend instance as failed state and start health check. |
+| SuccNum       | Int<br>Healthy threshold (consecutive successes of health check request), which will trigger BFE to set backend instance as healthy state and stop health check. |
+| CheckTimeout  | Int<br>Timeout for health check, in ms. Default value is 0, which means no timeout. |
+| CheckInterval | Int<br>Interval of health check, in ms. Default value is 1000. |
 
 #### GSLB Config
 
 GslbBasic is cluster config for Gslb.
 
-| Config Item | Description                                                  |
-| ----------- | ------------------------------------------------------------ |
-| CrossRetry  | Int<br>Cross sub-clusters retry times                               |
-| RetryMax    | Int<br>Inner cluster retry times                                    |
-| BalanceMode | String<br>BalanceMode, default WRR                                     |
-| HashConf    | Struct<br>Hash config about load balabnce<br>- HashStrategy: HashStrategy is hash strategy for subcluster-level load balance. Such as ClientIdOnly, ClientIpOnly, ClientIdPreferred<br>- HashHeader: HashHeader is an optional request header which represents a unique client. Format for speicial cookie header is "Cookie:Key"<br>- SessionSticky: SessionSticky enable sticky session (ensures that all requests from the user during the session are sent to the same backend) |
+| Config Item           | Description                                                  |
+| --------------------- | ------------------------------------------------------------ |
+| CrossRetry            | Int<br>Max cross sub-clusters retry times. Default value is 0. |
+| RetryMax              | Int<br>Max retry times within same sub-cluster. Default value is 2. |
+| BalanceMode           | String<br>Load Balance Mode. Supported mode: WRR(Weighted Round Robin), WLC(Weighted Least Connection). Default value is WRR. |
+| HashConf              | Struct<br>Hash config of session persistence<br>             |
+| HashConf.HashStrategy | Int<br>Hash Strategy of session persistence. Supported strategy: 0: ClientIdOnly, 1: ClientIpOnly, 2: ClientIdPreferred, 3: RequestURI. Default value is 1 (ClientIpOnly).<br> |
+| HashConf.HashHeader   | String<br>HashHeader is an optional request header which represents a unique client. Format for speicial cookie header is "Cookie:Key"<br> |
+| HashConf.SessonSticky | Boolean<br>Set SessionSticky to "true" enable sticky session (ensures that all requests from the user during the session are sent to the same backend). If set to "false", the session persistence will be at sub-cluster level. |
 
 #### Cluster Basic Config
 
@@ -62,13 +69,13 @@ ClusterBasic is basic config for cluster.
 
 | Config Item            | Description                                                  |
 | ---------------------- | ------------------------------------------------------------ |
-| TimeoutReadClient      | Int<br>Timeout for read client body in ms                           |
-| TimeoutWriteClient     | Int<br>Timeout for write response to client                         |
-| TimeoutReadClientAgain | Int<br>Timeout for read client again in ms                          |
-| ReqWriteBufferSize     | Int<br>Write buffer size for request in byte                        |
-| ReqFlushInterval       | Int<br>Interval to flush request in ms. if zero, disable periodic flush |
-| ResFlushInterval       | Int<br>Interval to flush response in ms. if zero, disable periodic flush |
-| CancelOnClientClose    | Bool<br>Cancel blocking operation on server if client connection disconnected |
+| TimeoutReadClient      | Int<br>Timeout for read client body in ms. Default value is 30000. |
+| TimeoutWriteClient     | Int<br>Timeout for write response to client. Default value is 60000. |
+| TimeoutReadClientAgain | Int<br>Timeout for read client again in ms. Default value is 60000. |
+| ReqWriteBufferSize     | Int<br>Write buffer size for request in byte. Default and recommended value is 512. |
+| ReqFlushInterval       | Int<br>Interval to flush request in ms. Default and recommended value is 0, means disable periodic flush. |
+| ResFlushInterval       | Int<br>Interval to flush response in ms. Default and recommended value is -1, means not to cache response. 0 means disable periodic flush. |
+| CancelOnClientClose    | Bool<br>During reading response from backend, cancel the blocking status if client connection disconnected. Default and recommended value is false. |
 
 ## Example
 ```json
@@ -104,7 +111,7 @@ ClusterBasic is basic config for cluster.
             "ClusterBasic": {
                 "TimeoutReadClient": 30000,
                 "TimeoutWriteClient": 60000,
-                "TimeoutReadClientAgain": 30000,
+                "TimeoutReadClientAgain": 60000,
                 "ReqWriteBufferSize": 512,
                 "ReqFlushInterval": 0,
                 "ResFlushInterval": -1,
@@ -145,7 +152,7 @@ ClusterBasic is basic config for cluster.
             "ClusterBasic": {
                 "TimeoutReadClient": 30000,
                 "TimeoutWriteClient": 60000,
-                "TimeoutReadClientAgain": 30000,
+                "TimeoutReadClientAgain": 60000,
                 "ReqWriteBufferSize": 512,
                 "ReqFlushInterval": 0,
                 "ResFlushInterval": -1,

--- a/docs/en_us/configuration/server_data_conf/cluster_conf.data.md
+++ b/docs/en_us/configuration/server_data_conf/cluster_conf.data.md
@@ -15,7 +15,7 @@ cluster_conf.data records the cluster config.
 
 ### Cluster Config Detail
 
-Notice: below config are in namespace Config[v].
+Notice: the following configs are in namespace Config[v].
 
 #### Backend Config
 
@@ -23,13 +23,13 @@ BackendConf is config for backend.
 
 | Config Item           | Description                                 |
 | --------------------- | ------------------------------------------- |
-| Protocol              | String<br>Protocol for connect backend, support http and fcgi. Default value is http |
-| TimeoutConnSrv        | Int<br>Timeout for connect backend, in ms. Default value is 2000 |
-| TimeoutResponseHeader | Int<br>Timeout for read response header, in ms. Default value is 60000 |
+| Protocol              | String<br>Protocol for connecting backend, http and fcgi are supported. Default value is http |
+| TimeoutConnSrv        | Int<br>Timeout for connecting backend, in ms. Default value is 2000 |
+| TimeoutResponseHeader | Int<br>Timeout for reading response header, in ms. Default value is 60000 |
 | MaxIdleConnsPerHost   | Int<br>Max idle connections to each backend per BFE. Default value is 2. |
 | MaxConnsPerHost   | Int<br>Max number of concurrent connections to each backend per BFE. 0 means no limitation. Default value is 0. |
-| RetryLevel            | Int<br>Retry level if request fail. 0: retry after connect backend fails; 1: retry after connect backend fails or forwarding GET request fails. Default value is 0. |
-| BackendConf.OutlierDetectionHttpCode            | String<br>Backend HTTP status code status detection. <br>"" means disable detection, "500" means consider "500" as backend failure and increase counter by 1. <br>Status code use format "dxx"(e.g "500"); separate multiple status code by "\|".<br>Default value is "", means disable detection. |
+| RetryLevel            | Int<br>Retry level if request fail. 0: retry after connecting backend fails; 1: retry after connecting backend fails or forwarding GET request fails. Default value is 0. |
+| BackendConf.OutlierDetectionHttpCode            | String<br>Backend HTTP status code status detection. <br>"" means disable detection, "500" means "500" is considered as backend failure and increase counter by 1. <br>Status code use format "[0-9]{3}"(e.g "500"); multiple status codes are seperated by "\|".<br>Default value is "", means disable detection. |
 | FCGIConf              | Object<br>Conf for FastCGI Protocol                |
 | FCGIConf.Root         | String<br>the root folder of the website       |
 | FCGIConf.EnvVars      | Map[string]string<br>extra environment variable    |
@@ -43,7 +43,7 @@ CheckConf is config of backend check.
 | Schem         | String<br>Protocol for health check (HTTP/TCP). Default value is http. |
 | Uri           | String<br>Uri used in health check (HTTP only). Default value is "/health_check". |
 | Host          | String<br>Host used in health check (HTTP only). Default value is "". |
-| StatusCode    | Int<br>Expected response code (HTTP only). Default value is 200. And 0 means any response code is considered expected. |
+| StatusCode    | Int<br>Expected response code (HTTP only). Default value is 200. And 0 means any response code is considered valid. |
 | FailNum       | Int<br>Failure threshold (consecutive failures of forwarded requests ), which will trigger BFE to set backend instance to unavailable state and start the health check. |
 | SuccNum       | Int<br>Healthy threshold (consecutive successes of health check request), which will trigger BFE to set backend instance to available state and stop the health check. |
 | CheckTimeout  | Int<br>Timeout for health check, in ms. Default value is 0, which means no timeout. |

--- a/docs/zh_cn/configuration/server_data_conf/cluster_conf.data.md
+++ b/docs/zh_cn/configuration/server_data_conf/cluster_conf.data.md
@@ -24,8 +24,8 @@ cluster_conf.data为集群转发配置文件。
 | 配置项                        | 描述                                                         |
 | ----------------------------- | ------------------------------------------------------------ |
 | BackendConf.Protocol              | String<br>后端服务的协议，当前支持http和fcgi, 默认值http |
-| BackendConf.TimeoutConnSrv        | Integer<br>连接后端的超时时间，单位是毫秒<br>默认值2 |
-| BackendConf.TimeoutResponseHeader | Integer<br>从后端读响应头的超时时间，单位是毫秒<br>默认值60 |
+| BackendConf.TimeoutConnSrv        | Integer<br>连接后端的超时时间，单位是毫秒<br>默认值2000 |
+| BackendConf.TimeoutResponseHeader | Integer<br>从后端读响应头的超时时间，单位是毫秒<br>默认值60000 |
 | BackendConf.MaxIdleConnsPerHost   | Integer<br>BFE实例与每个后端的最大空闲长连接数<br>默认值2 |
 | BackendConf.MaxConnsPerHost   | Integer<br>BFE实例与每个后端的最大长连接数，0代表无限制<br>默认值0 |
 | BackendConf.RetryLevel            | Integer<br>请求重试级别。0：连接后端失败时，进行重试；1：连接后端失败、转发GET请求失败时均进行重试<br>默认值0 |
@@ -39,33 +39,37 @@ cluster_conf.data为集群转发配置文件。
 | 配置项                   | 描述                                                         |
 | ------------------------ | ------------------------------------------------------------ |
 | CheckConf.Schem         | String<br>健康检查协议，支持HTTP和TCP<br>默认值 HTTP         |
-| CheckConf.Uri           | String<br>健康检查请求URI (仅HTTP)<br>默认值 /health_check   |
+| CheckConf.Uri           | String<br>健康检查请求URI (仅HTTP)<br>默认值 "/health_check" |
 | CheckConf.Host          | String<br>健康检查请求HOST (仅HTTP)<br>默认值 ""             |
-| CheckConf.StatusCode    | Integer<br>期待返回的响应状态码 (仅HTTP)<br>默认值 0，代表任意状态码 |
+| CheckConf.StatusCode    | Integer<br>期待返回的响应状态码 (仅HTTP)<br>默认值 200。也可以配置为0，代表任意状态码均符合预期。 |
 | CheckConf.FailNum       | Integer<br>健康检查启动阈值（转发请求连续失败FailNum次后，将后端实例置为不可用状态，并启动健康检查）<br>默认值5 |
 | CheckConf.SuccNum       | Integer<br>健康检查成功阈值（健康检查连续成功SuccNum次后，将后端实例置为可用状态）<br>默认值1 |
 | CheckConf.CheckTimeout  | Integer<br>健康检查的超时时间，单位是毫秒<br>默认值0（无超时）|
-| CheckConf.CheckInterval | Integer<br>健康检查的间隔时间，单位是毫秒<br>默认值1 |
+| CheckConf.CheckInterval | Integer<br>健康检查的间隔时间，单位是毫秒<br>默认值1000 |
 
 #### GSLB基础配置
 
-| 配置项                           | 描述                                       |
-| -------------------------------- | ------------------------------------------ |
-| GslbBasic.CrossRetry             | Integer<br>跨子集群最大重试次数<br>默认值0 |
-| GslbBasic.RetryMax               | Integer<br>子集群内最大重试次数<br>默认值2 |
+| 配置项                           | 描述                                                         |
+| -------------------------------- | ------------------------------------------------------------ |
+| GslbBasic.CrossRetry             | Integer<br>跨子集群最大重试次数<br>默认值0                   |
+| GslbBasic.RetryMax               | Integer<br>子集群内最大重试次数<br>默认值2                   |
 | GslbBasic.BalanceMode            | String<br>负载均衡模式(WRR: 加权轮询; WLC: 加权最小连接数)<br>默认值WRR |
-| GslbBasic.HashConf               | Object<br>会话保持的HASH策略配置 |
-| GslbBasic.HashConf.HashStrategy  | Integer<br>会话保持的哈希策(ClientIdOnly, ClientIpOnly, ClientIdPreferred)<br>默认值ClientIpOnly |
-| GslbBasic.HashConf.HashHeader    | String<br>会话保持的hash请求头 |
-| GslbBasic.HashConf.SessionSticky | Boolean<br>是否开启会话保持（开启后，可以保证来源于同一个用户的请求可以发送到同一个后端）<br>默认值False |
+| GslbBasic.HashConf               | Object<br>会话保持的HASH策略配置                             |
+| GslbBasic.HashConf.HashStrategy  | Integer<br>会话保持的哈希策。0：ClientIdOnly, 1：ClientIpOnly, 2：ClientIdPreferred，3：RequestURI<br>默认值为0(ClientIpOnly) |
+| GslbBasic.HashConf.HashHeader    | String<br>会话保持的hash请求头。可选参数。可配置为能用于唯一区分一个客户端的Header。如果是一个cookie header, 格式为："Cookie:key" |
+| GslbBasic.HashConf.SessionSticky | Boolean<br>是否开启会话保持（开启后，可以保证来源于同一个用户的请求可以发送到同一个后端）<br>默认值False。设为False时，会话保持级别为子集群级别。 |
 
 #### 集群基础配置
 
-| 配置项                              | 描述                                                        |
-| ----------------------------------- | ----------------------------------------------------------- |
-| ClusterBasic.TimeoutReadClient      | Integer<br>读用户请求body的超时时间，单位为毫秒<br>默认值30 |
-| ClusterBasic.TimeoutWriteClient     | Integer<br>写响应的超时时间，单位为毫秒<br>默认值60         |
-| ClusterBasic.TimeoutReadClientAgain | Integer<br>连接闲置超时时间，单位为毫秒<br>默认值60         |
+| 配置项                              | 描述                                                         |
+| ----------------------------------- | ------------------------------------------------------------ |
+| ClusterBasic.TimeoutReadClient      | Integer<br>读用户请求body的超时时间，单位为毫秒<br>默认值30000 |
+| ClusterBasic.TimeoutWriteClient     | Integer<br>写响应的超时时间，单位为毫秒<br>默认值60000       |
+| ClusterBasic.TimeoutReadClientAgain | Integer<br>连接闲置超时时间，单位为毫秒<br>默认值60000       |
+| ClusterBasic.ReqWriteBufferSize     | Integer<br>请求的写buffer大小，单位为Bytes。默认值512。建议使用默认值。 |
+| ClusterBasic.ReqFlushInterval       | Integer<br>刷新请求的间隔时间，单位是毫秒。默认值为0，表示不进行周期性刷新 |
+| ClusterBasic.ResFlushInterval       | Integer<br>刷新响应的间隔时间，单位是毫秒。默认值为-1，表示不对响应进行缓存。设置为0表示不进行周期性刷新。建议使用默认值。 |
+| ClusterBasic.CancelOnClientClose    | Boolean<br>当服务端正在读后端响应时，如果客户端断连，是否取消该阻塞状态。默认值为false。建议使用默认值。 |
 
 ## 配置示例
 
@@ -101,7 +105,7 @@ cluster_conf.data为集群转发配置文件。
             "ClusterBasic": {
                 "TimeoutReadClient": 30000,
                 "TimeoutWriteClient": 60000,
-                "TimeoutReadClientAgain": 30000,
+                "TimeoutReadClientAgain": 60000,
             }
         },
         "fcgi_cluster_example": {
@@ -139,7 +143,7 @@ cluster_conf.data为集群转发配置文件。
             "ClusterBasic": {
                 "TimeoutReadClient": 30000,
                 "TimeoutWriteClient": 60000,
-                "TimeoutReadClientAgain": 30000,
+                "TimeoutReadClientAgain": 60000,
                 "ReqWriteBufferSize": 512,
                 "ReqFlushInterval": 0,
                 "ResFlushInterval": -1,

--- a/docs/zh_cn/configuration/server_data_conf/cluster_conf.data.md
+++ b/docs/zh_cn/configuration/server_data_conf/cluster_conf.data.md
@@ -55,7 +55,7 @@ cluster_conf.data为集群转发配置文件。
 | GslbBasic.RetryMax               | Integer<br>子集群内最大重试次数<br>默认值2                   |
 | GslbBasic.BalanceMode            | String<br>负载均衡模式(WRR: 加权轮询; WLC: 加权最小连接数)<br>默认值WRR |
 | GslbBasic.HashConf               | Object<br>会话保持的HASH策略配置                             |
-| GslbBasic.HashConf.HashStrategy  | Integer<br>会话保持的哈希策。0：ClientIdOnly, 1：ClientIpOnly, 2：ClientIdPreferred，3：RequestURI<br>默认值为0(ClientIpOnly) |
+| GslbBasic.HashConf.HashStrategy  | Integer<br>会话保持的哈希策略。0：ClientIdOnly, 1：ClientIpOnly, 2：ClientIdPreferred，3：RequestURI<br>默认值为0(ClientIpOnly) |
 | GslbBasic.HashConf.HashHeader    | String<br>会话保持的hash请求头。可选参数。可配置为能用于唯一区分一个客户端的Header。如果是一个cookie header, 格式为："Cookie:key" |
 | GslbBasic.HashConf.SessionSticky | Boolean<br>是否开启会话保持（开启后，可以保证来源于同一个用户的请求可以发送到同一个后端）<br>默认值False。设为False时，会话保持级别为子集群级别。 |
 


### PR DESCRIPTION
Improve and fix error in document  cluster_conf.data.md 
1. Fix issue #833 about document
2. Correct other default value description in cluster_conf.data.md 
3. Update english version of  cluster_conf.data.md to sync up with chinese version
4. Fix other minor issues in cluster_conf.data.md 
5. Add description of below parameter back to chinese version:
                "ReqWriteBufferSize": 512,
                "ReqFlushInterval": 0,
                "ResFlushInterval": -1,
                "CancelOnClientClose": false
