### PR TITLE
bugfix: start bfe monitor web server only when enable

### DIFF
--- a/bfe_server/bfe_server_init.go
+++ b/bfe_server/bfe_server_init.go
@@ -58,13 +58,11 @@ func StartUp(cfg bfe_conf.BfeConfig, version string, confRoot string) error {
 	bfeServer.InitSignalTable()
 	log.Logger.Info("StartUp():bfeServer.InitSignalTable() OK")
 
-	// init web monitor if enabled
-	if cfg.Server.MonitorEnabled {
-		monitorPort := cfg.Server.MonitorPort
-		if err = bfeServer.InitWebMonitor(monitorPort); err != nil {
-			log.Logger.Error("StartUp(): InitWebMonitor():%s", err.Error())
-			return err
-		}
+	// init web monitor
+	monitorPort := cfg.Server.MonitorPort
+	if err = bfeServer.InitWebMonitor(monitorPort); err != nil {
+		log.Logger.Error("StartUp(): InitWebMonitor():%s", err.Error())
+		return err
 	}
 
 	// register modules
@@ -101,8 +99,10 @@ func StartUp(cfg bfe_conf.BfeConfig, version string, confRoot string) error {
 		return err
 	}
 
-	// start embedded web server
-	bfeServer.Monitor.Start()
+	// start embedded web server if enabled
+	if cfg.Server.MonitorEnabled {
+		bfeServer.Monitor.Start()
+	}
 
 	serveChan := make(chan error)
 


### PR DESCRIPTION
bug `bfe launch failed when disable monitor server` was imported by #937 

solution: 

1. remove `MonitorEnable` check when `InitWebMonitor`, always do this initialization

1. monitor server doesn't startup when disable