### PR TITLE
typo: code span on function prototype of bfe callback

### DIFF
--- a/docs/en_us/development/module/bfe_callback.md
+++ b/docs/en_us/development/module/bfe_callback.md
@@ -57,7 +57,7 @@ Note: For the meaning of type int in the return value below, please refer to "Re
     + HandleAccept
     + HandleHandshake
 - Function prototype:
-    + handler(session *bfe_basic.Session) int
+    + `handler(session *bfe_basic.Session) int`
 
 ### HandlersRequest
 
@@ -66,14 +66,14 @@ Note: For the meaning of type int in the return value below, please refer to "Re
     + HandleFoundProduct
     + HandleAfterLocation
 - Function prototype:
-    + handler(req *bfe_basic.Request) (int,*bfe_http.Response)
+    + `handler(req *bfe_basic.Request) (int, *bfe_http.Response)`
 
 ### HandlersForward
 
 - Applicable callback point:
     + HandleForward
 - Function prototype:
-    + handler(req *bfe_basic.Request) int
+    + `handler(req *bfe_basic.Request) int`
 
 ### HandlersResponse
 
@@ -81,11 +81,11 @@ Note: For the meaning of type int in the return value below, please refer to "Re
     + HandleReadResponse
     + HandleRequestFinish
 - Function prototype:
-    + handler(req *bfe_basic.Request, res *bfe_http.Response) int
+    + `handler(req *bfe_basic.Request, res *bfe_http.Response) int`
 
 ### HandlersFinish
 
 - Applicable callback point:
     + HandleFinish
 - Function prototype:
-    + handler(session *bfe_basic.Session) int
+    + `handler(session *bfe_basic.Session) int`

--- a/docs/zh_cn/development/module/bfe_callback.md
+++ b/docs/zh_cn/development/module/bfe_callback.md
@@ -57,7 +57,7 @@ BFE转发过程中的回调点如下图所示。
     + HandleAccept
     + HandleHandshake
 - 回调函数形式：
-    + handler(session *bfe_basic.Session) int
+    + `handler(session *bfe_basic.Session) int`
 
 ### HandlersRequest
 
@@ -66,14 +66,14 @@ BFE转发过程中的回调点如下图所示。
     + HandleFoundProduct
     + HandleAfterLocation
 - 回调函数形式：
-    + handler(req *bfe_basic.Request) (int,*bfe_http.Response)
+    + `handler(req *bfe_basic.Request) (int, *bfe_http.Response)`
 
 ### HandlersForward
 
 - 适用回调点：
     + HandleForward
 - 回调函数形式：
-    + handler(req *bfe_basic.Request) int
+    + `handler(req *bfe_basic.Request) int`
 
 ### HandlersResponse
 
@@ -81,11 +81,11 @@ BFE转发过程中的回调点如下图所示。
     + HandleReadResponse
     + HandleRequestFinish
 - 回调函数形式：
-    + handler(req *bfe_basic.Request, res *bfe_http.Response) int
+    + `handler(req *bfe_basic.Request, res *bfe_http.Response) int`
 
 ### HandlersFinish
 
 - 适用回调点：
     + HandleFinish
 - 回调函数形式：
-    + handler(session *bfe_basic.Session) int
+    + `handler(session *bfe_basic.Session) int`


### PR DESCRIPTION
- mark code span on function prototype, like `handler(req *bfe_basic.Request, res *bfe_http.Response) int`