### PR TITLE
typo: fix docs/monitor markdown lint and syntax

### DIFF
--- a/docs/en_us/monitor/bal_state.md
+++ b/docs/en_us/monitor/bal_state.md
@@ -13,4 +13,3 @@ The endpoint `/monitor/bal_state` exposes metrics about subcluster level load ba
 | ERR_BK_NO_SUB_CLUSTER_CROSS | Counter for no cross sub-cluster found |
 | ERR_BK_RETRY_TOO_MANY       | Counter for reaching retry max times   |
 | ERR_GSLB_BLACKHOLE          | Counter for denying by blackhole       |
-

--- a/docs/en_us/monitor/bal_table_status.md
+++ b/docs/en_us/monitor/bal_table_status.md
@@ -17,4 +17,3 @@ The endpoint `/monitor/bal_table_status` exposes metrics about backend clusters.
 | ------------ | ------------------------------------------------------------ |
 | SubClusters  | State of sub-cluster, it is map data, key is sub-cluster name, value is number of sub-cluster backend |
 | BackendNum   | Number of sub-cluster backend                                |
-

--- a/docs/en_us/monitor/http2_state.md
+++ b/docs/en_us/monitor/http2_state.md
@@ -11,7 +11,7 @@ The endpoint `/monitor/http2_state` exposes metrics about HTTP2 protocol.
 | H2_ERR_MAX_HEADER_LIST_SIZE | Counter for reaching max size of header list            |
 | H2_ERR_MAX_HEADER_URI_SIZE  | Counter for reaching max size of header URI             |
 | H2_ERR_MAX_STREAM_PER_CONN  | Counter for reaching advertised concurrent stream limit |
-| H2_ERR_GOT_RESET            | Counter for gettting RST_STREAM                         |
+| H2_ERR_GOT_RESET            | Counter for getting RST_STREAM                         |
 | H2_PANIC_CONN               | Counter for connection panic                            |
 | H2_PANIC_STREAM             | Counter for stream panic                                |
 | H2_REQ_HEADER_COMPRESS_SIZE | Size of request header after compress                   |
@@ -23,4 +23,3 @@ The endpoint `/monitor/http2_state` exposes metrics about HTTP2 protocol.
 | H2_TIMEOUT_READ_STREAM      | Counter for timeout of waiting for reading stream       |
 | H2_TIMEOUT_SETTING          | Counter for timeout of waiting for SETTINGS frames      |
 | H2_TIMEOUT_WRITE_STREAM     | Counter for timeout of waiting for writing stream       |
-

--- a/docs/en_us/monitor/http_state.md
+++ b/docs/en_us/monitor/http_state.md
@@ -16,4 +16,3 @@ The endpoint `/monitor/http_state` exposes metrics about HTTP protocol.
 | HTTP_PANIC_BACKEND_WRITE     | Counter for writing backend panic                            |
 | HTTP_PANIC_CLIENT_FLUSH_LOOP | Counter for client flushing loop panic                       |
 | HTTP_PANIC_CLIENT_WATCH_LOOP | Counter for client watching loop panic                       |
-

--- a/docs/en_us/monitor/latency.md
+++ b/docs/en_us/monitor/latency.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-| Endpoint                              | Description       | 
+| Endpoint                              | Description       |
 | ------------------------------------- | ----------------- |
 | /monitor/proxy_handshake_delay        | Latency of the TLS handshake |
 | /monitor/proxy_handshake_full_delay   | Latency of the TLS full handshake |
@@ -18,13 +18,13 @@
 | ProgramName  | Program name                              |
 | KeyPrefix    | Key prefix                                |
 | CurrTime     | Start time of current statistics          |
-| Current      | Latency histgram for current statistics   |
+| Current      | Latency histogram for current statistics   |
 | PastTime     | Start time of last statistics             |
-| Past         | Latency histgram for last statistics      |
+| Past         | Latency histogram for last statistics      |
 
 ## Special Notes for Prometheus format
 
-BFE can expose metrics in various formats. 
+BFE can expose metrics in various formats.
 
 Unlike other formats, in the Prometheus format latency histogram, counter for a bucket with lager upper bound will include the number of events in buckets with smaller upper bound.  See [Histogram](https://prometheus.io/docs/concepts/metric_types/#histogram) in Prometheus document for more detail.  
 

--- a/docs/en_us/monitor/module_status.md
+++ b/docs/en_us/monitor/module_status.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-The endpoint `/monitor/modules` exposes informations about modules.
+The endpoint `/monitor/modules` exposes information about modules.
 
 ## Metrics
 
@@ -12,4 +12,3 @@ The endpoint `/monitor/modules` exposes informations about modules.
 | enabled      | List of enable modules    |
 
 For more details about metrics of each module, see [BFE modules](../modules/modules.md).
-

--- a/docs/en_us/monitor/proxy_mem_stat.md
+++ b/docs/en_us/monitor/proxy_mem_stat.md
@@ -1,4 +1,4 @@
-# Memory 
+# Memory
 
 ## Introduction
 
@@ -7,4 +7,3 @@ The endpoint `/monitor/proxy_mem_stat` expose information about memory.
 ## Metrics
 
 See [golang runtime.MemStats](https://golang.org/pkg/runtime/#MemStats)
-

--- a/docs/en_us/monitor/tls_state.md
+++ b/docs/en_us/monitor/tls_state.md
@@ -24,4 +24,3 @@ The endpoint `/monitor/tls_state` exposes metrics about TLS protocol.
 | TLS_HANDSHAKE_SSLV2_NOT_SUPPORT            | Counter for unsupported SSLv2 handshake received             |
 | TLS_HANDSHAKE_ZERO_DATA                    | Counter for zero data                                        |
 | TLS_STATUS_REQUEST_EXT_COUNT               | Counter for request extensions                               |
-

--- a/docs/en_us/monitor/websocket_state.md
+++ b/docs/en_us/monitor/websocket_state.md
@@ -17,4 +17,3 @@ The endpoint `/monitor/websocket_state` exposes metrics about WebSocket.
 | WEB_SOCKET_ERR_PROXY          | Counter for finding backend           |
 | WEB_SOCKET_ERR_TRANSFER       | Counter for transfer error            |
 | WEB_SOCKET_PANIC_CONN         | Counter for connection panic          |
-

--- a/docs/zh_cn/monitor/bal_state.md
+++ b/docs/zh_cn/monitor/bal_state.md
@@ -13,4 +13,3 @@
 | ERR_BK_NO_SUB_CLUSTER_CROSS | 跨子集群转发时，未找到子集群的错误数 |
 | ERR_BK_RETRY_TOO_MANY       | 转发请求达到最大重试次数的错误数    |
 | ERR_GSLB_BLACKHOLE          | 转发到黑洞（被丢弃）的请求数        |
-

--- a/docs/zh_cn/monitor/module_status.md
+++ b/docs/zh_cn/monitor/module_status.md
@@ -12,4 +12,3 @@
 | enabled   | 启用的模块列表 |
 
 关于各模块监控项, 详见[模块说明](../modules/modules.md)
-

--- a/docs/zh_cn/monitor/proxy_state.md
+++ b/docs/zh_cn/monitor/proxy_state.md
@@ -18,7 +18,6 @@
 | CLIENT_REQ_SERVED               | 处理请求数               |
 | CLIENT_REQ_FAIL                 | 转发失败的请求数          |
 
-
 ### 后端相关错误
 
 | 监控项                           | 描述                   |
@@ -33,7 +32,6 @@
 | ERR_BK_RESP_HEADER_TIMEOUT      | 读后端响应头超时的错误数   |
 | ERR_BK_TRANSPORT_BROKEN         | 与后端连接异常的错误数     |
 | ERR_BK_WRITE_REQUEST            | 向后端写请求失败的错误数   |
-
 
 ### 客户端相关错误
 
@@ -50,7 +48,6 @@
 | ERR_CLIENT_WRITE                | 向客户端发送响应错误数        |
 | ERR_CLIENT_ZERO_CONTENTLEN      | 对于100-continue请求，Content-Length为0错误数 |
 
-
 ### Panic相关异常
 
 | 监控项                           | 描述                   |
@@ -58,7 +55,6 @@
 | PANIC_BACKEND_READ              | 读后端协程panic的次数    |
 | PANIC_BACKEND_WRITE             | 写后端协程panic的次数    |
 | PANIC_CLIENT_CONN_SERVE         | 客户端连接协程panic的次数 |
-
 
 ### 流量相关
 
@@ -86,7 +82,6 @@
 | WSS_CLIENT_CONN_SERVED          | WSS协议处理连接数    |
 | WS_CLIENT_CONN_ACTIVE           | WS协议活跃连接数     |
 | WS_CLIENT_CONN_SERVED           | WS协议处理连接数     |
-
 
 ### TLS协议相关
 

--- a/docs/zh_cn/monitor/tls_state.md
+++ b/docs/zh_cn/monitor/tls_state.md
@@ -24,4 +24,3 @@
 | TLS_HANDSHAKE_SSLV2_NOT_SUPPORT            | 不支持SSLv2版本握手的次数                          |
 | TLS_HANDSHAKE_ZERO_DATA                    | 客户端建立连接后未发送消息的错误数                 |
 | TLS_STATUS_REQUEST_EXT_COUNT               | ClientHello携带Certificate Status Request扩展的次数|
-

--- a/docs/zh_cn/monitor/websocket_state.md
+++ b/docs/zh_cn/monitor/websocket_state.md
@@ -17,4 +17,3 @@
 | WEB_SOCKET_ERR_PROXY          | 无可用后端错误数                    |
 | WEB_SOCKET_ERR_TRANSFER       | 数据传输的错误数                    |
 | WEB_SOCKET_PANIC_CONN         | 连接PANIC的异常数                   |
-


### PR DESCRIPTION
- trim tailing space
- remove redundant space line
- fix some words spelling error