### PR TITLE
typo: fix docs/condition markdown lints

### DIFF
--- a/docs/en_us/condition/condition_primitive_index.md
+++ b/docs/en_us/condition/condition_primitive_index.md
@@ -40,7 +40,7 @@
 
 ### path
 
- * [req_path_contain(path_list, case_insensitive)](./request/uri.md#req_path_containpath_list-case_insensitive) 
+ * [req_path_contain(path_list, case_insensitive)](./request/uri.md#req_path_containpath_list-case_insensitive)
  * [req_path_element_prefix_in(prefix_list, case_insensitive)](./request/uri.md#req_path_element_prefix_inprefix_list-case_insensitive)
  * [req_path_in(path_list, case_insensitive)](./request/uri.md#req_path_inpath_list-case_insensitive)
  * [req_path_prefix_in(prefix_list, case_insensitive)](./request/uri.md#req_path_prefix_inprefix_list-case_insensitive)
@@ -76,7 +76,6 @@
  * [req_vip_in(vip_list)](./request/ip.md#req_vip_invip_list)
  * [req_vip_range(start_ip, end_ip)](./request/ip.md#req_vip_rangestart_ip-end_ip)
 
-
 ## Response Primitive
 
 ### code
@@ -88,7 +87,6 @@
  * [res_header_key_in(key_list)](./response/header.md#res_header_key_inkey_list)
  * [res_header_value_in(key, value_list, case_insensitive)](./response/header.md#res_header_value_inkey-value_list-case_insensitive)
 
-
 ## Session Primitive
 
 ### sip
@@ -96,6 +94,7 @@
  * [ses_sip_range(start_ip, end_ip)](./session/ip.md#ses_sip_rangestart_ip-end_ip)
 
 ### tls client
+
  * [ses_tls_client_auth()](./session/tls.md#ses_tls_client_auth)
  * [ses_tls_client_ca_in(ca_list)](./session/tls.md#ses_tls_client_ca_inca_list)
 
@@ -104,8 +103,8 @@
  * [ses_tls_sni_in(host_list)](./session/tls.md#ses_tls_sni_inhost_list)
 
 ### vip
- * [ses_vip_range(start_ip, end_ip)](./session/ip.md#ses_vip_rangestart_ip-end_ip)
 
+ * [ses_vip_range(start_ip, end_ip)](./session/ip.md#ses_vip_rangestart_ip-end_ip)
 
 ## System Primitive
 

--- a/docs/zh_cn/condition/condition_primitive_index.md
+++ b/docs/zh_cn/condition/condition_primitive_index.md
@@ -40,7 +40,7 @@
 
 ### path
 
- * [req_path_contain(path_list, case_insensitive)](./request/uri.md#req_path_containpath_list-case_insensitive) 
+ * [req_path_contain(path_list, case_insensitive)](./request/uri.md#req_path_containpath_list-case_insensitive)
  * [req_path_element_prefix_in(prefix_list, case_insensitive)](./request/uri.md#req_path_element_prefix_inprefix_list-case_insensitive)
  * [req_path_in(path_list, case_insensitive)](./request/uri.md#req_path_inpath_list-case_insensitive)
  * [req_path_prefix_in(prefix_list, case_insensitive)](./request/uri.md#req_path_prefix_inprefix_list-case_insensitive)
@@ -94,6 +94,7 @@
  * [ses_sip_range(start_ip, end_ip)](./session/ip.md#ses_sip_rangestart_ip-end_ip)
 
 ### tls client
+
  * [ses_tls_client_auth()](./session/tls.md#ses_tls_client_auth)
  * [ses_tls_client_ca_in(ca_list)](./session/tls.md#ses_tls_client_ca_inca_list)
 
@@ -102,6 +103,7 @@
  * [ses_tls_sni_in(host_list)](./session/tls.md#ses_tls_sni_inhost_list)
 
 ### vip
+
  * [ses_vip_range(start_ip, end_ip)](./session/ip.md#ses_vip_rangestart_ip-end_ip)
 
 ## 系统相关
@@ -110,4 +112,3 @@
 
  * [bfe_periodic_time_range(start_time, end_time, period)](./system/time.md#bfe_periodic_time_rangestart_time-end_time-period)
  * [bfe_time_range(start_time, end_time)](./system/time.md#bfe_time_rangestart_time-end_time)
- 


### PR DESCRIPTION
- add newline under header
- remove trailing space