### PR TITLE
chore: add staticcheck pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,9 +14,14 @@
 #
 repos:
 - repo: git://github.com/dnephin/pre-commit-golang
-  rev: v0.4.0
+  rev: v0.5.0
   hooks:
     - id: go-fmt
     - id: go-vet
     - id: go-unit-tests
     - id: go-build
+
+- repo: git://github.com/Bahjat/pre-commit-golang
+  rev: c3086eea8af86847dbdff2e46b85a5fe3c9d9656
+  hooks:
+    - id: go-static-check


### PR DESCRIPTION
* upgrade [pre-commit-golang](git://github.com/dnephin/pre-commit-golang) to v0.5.0
* enable `staticcheck` hook on pre-commit

related issue https://github.com/bfenetworks/bfe/issues/1017#issuecomment-1057687624

test case:

```bash
➜  bfe git:(precommit-sc) ✗ git add bfe_cli/a.go 
➜  bfe git:(precommit-sc) ✗ git cm "test check"
go fmt...................................................................Passed
go vet...................................................................Passed
go-unit-tests............................................................Passed
go-build.................................................................Passed
go staticcheck...........................................................Failed
- hook id: go-static-check
- exit code: 1

bfe_cli/a.go:3:5: var name is unused (U1000)
bfe_cli/a.go:5:6: func main is unused (U1000)

```