### PR TITLE
优化空闲连接>MaxIdleConnsPerHost情况下处理

### DIFF
--- a/bfe_http/transport.go
+++ b/bfe_http/transport.go
@@ -380,10 +380,16 @@ func (t *Transport) putIdleConn(pconn *persistConn) bool {
 	if t.idleConn == nil {
 		t.idleConn = make(map[string][]*persistConn)
 	}
+	// if t.idleConn's length >= t.maxIdleConnsPerHost, will close the oldest connection.
+	// when a TCP socket is unused for a while the congestion window is reset, and next time it is used, it will
+	// be in slow start mode. So a recently used connection is likely to have a larger window size, and allow
+	// faster transmission, than one which has been idle for a long time.
 	if len(t.idleConn[key]) >= max {
+		oldest := t.idleConn[key][0]
+		t.idleConn[key] = append(t.idleConn[key][1:], pconn)
 		t.idleMu.Unlock()
-		pconn.close()
-		return false
+		oldest.close()
+		return true
 	}
 	for _, exist := range t.idleConn[key] {
 		if exist == pconn {

--- a/bfe_http/transport.go
+++ b/bfe_http/transport.go
@@ -380,10 +380,7 @@ func (t *Transport) putIdleConn(pconn *persistConn) bool {
 	if t.idleConn == nil {
 		t.idleConn = make(map[string][]*persistConn)
 	}
-	// if t.idleConn's length >= t.maxIdleConnsPerHost, will close the oldest connection.
-	// when a TCP socket is unused for a while the congestion window is reset, and next time it is used, it will
-	// be in slow start mode. So a recently used connection is likely to have a larger window size, and allow
-	// faster transmission, than one which has been idle for a long time.
+	// evict the oldest connection when idleConn exceed its limits.
 	if len(t.idleConn[key]) >= max {
 		oldest := t.idleConn[key][0]
 		t.idleConn[key] = append(t.idleConn[key][1:], pconn)


### PR DESCRIPTION
`putIdleConn`时，当空闲队列中的数量大于MaxIdleConnsPerHost时，将关闭空间时间最长的连接，而不是关闭当前新创建的连接。
原因：当tcp连接空闲一段时间后，拥塞窗口将会重置，下次启动时将以慢启动开始，最近的连接会有比较大的窗口大小，相对于已经空闲一段时间的连接，能够比较快速的进行数据传输。
