### PR TITLE
refactor: replace strings.Replace with strings.ReplaceAll

### DIFF
--- a/bfe_basic/action/action_query.go
+++ b/bfe_basic/action/action_query.go
@@ -109,7 +109,7 @@ func ReqQueryRename(req *bfe_basic.Request, oldName string, newName string) {
 	// rename keys
 	srcKey := "&" + oldName + "="
 	dstKey := "&" + newName + "="
-	rawQuery = strings.Replace(rawQuery, srcKey, dstKey, -1)
+	rawQuery = strings.ReplaceAll(rawQuery, srcKey, dstKey)
 
 	// remove prefix "&"
 	req.HttpRequest.URL.RawQuery = rawQuery[1:]

--- a/bfe_basic/condition/primitive.go
+++ b/bfe_basic/condition/primitive.go
@@ -875,7 +875,7 @@ func parserHashSectionConf(section string) (int, int, error) {
 	// checkt numbers
 	var start, end int
 	for i, numberRawStr := range numbers {
-		numberStr := strings.Replace(numberRawStr, " ", "", -1)
+		numberStr := strings.ReplaceAll(numberRawStr, " ", "")
 		number, err := strconv.Atoi(numberStr)
 		if err != nil {
 			return 0, 0, fmt.Errorf("hash value check section %s number %s err %s",

--- a/bfe_fcgi/transport.go
+++ b/bfe_fcgi/transport.go
@@ -131,7 +131,7 @@ func buildMetaValsAndMethod(r *http.Request, root string, envVars map[string]str
 
 	// https://tools.ietf.org/html/rfc3875#section-4.1.18
 	for key, val := range r.Header {
-		header := strings.Replace(strings.ToUpper(key), "-", "_", -1)
+		header := strings.ReplaceAll(strings.ToUpper(key), "-", "_")
 		metaHeader.Add("HTTP_"+header, strings.Join(val, ", "))
 	}
 

--- a/bfe_http/request_test.go
+++ b/bfe_http/request_test.go
@@ -405,7 +405,7 @@ func testMissingFile(t *testing.T, req *Request) {
 }
 
 func newTestMultipartRequest(t *testing.T) *Request {
-	b := bytes.NewBufferString(strings.Replace(message, "\n", "\r\n", -1))
+	b := bytes.NewBufferString(strings.ReplaceAll(message, "\n", "\r\n"))
 	req, err := NewRequest(MethodPost, "/", b)
 	if err != nil {
 		t.Fatal("NewRequest:", err)
@@ -498,7 +498,7 @@ Content-Disposition: form-data; name="textb"
 
 func benchmarkReadRequest(b *testing.B, request string) {
 	request += "\n"                                      // final \n
-	request = strings.Replace(request, "\n", "\r\n", -1) // expand \n to \r\n
+	request = strings.ReplaceAll(request, "\n", "\r\n") // expand \n to \r\n
 	b.SetBytes(int64(len(request)))
 	r := bfe_bufio.NewReader(&infiniteReader{buf: []byte(request)})
 	b.ReportAllocs()

--- a/bfe_http2/hpack/encode_test.go
+++ b/bfe_http2/hpack/encode_test.go
@@ -341,5 +341,5 @@ func TestEncoderSetMaxDynamicTableSizeLimit(t *testing.T) {
 }
 
 func removeSpace(s string) string {
-	return strings.Replace(s, " ", "", -1)
+	return strings.ReplaceAll(s, " ", "")
 }

--- a/bfe_http2/hpack/hpack_test.go
+++ b/bfe_http2/hpack/hpack_test.go
@@ -556,7 +556,7 @@ func TestHuffmanDecode(t *testing.T) {
 	}
 	for i, tt := range tests {
 		var buf bytes.Buffer
-		in, err := hex.DecodeString(strings.Replace(tt.inHex, " ", "", -1))
+		in, err := hex.DecodeString(strings.ReplaceAll(tt.inHex, " ", ""))
 		if err != nil {
 			t.Errorf("%d. hex input error: %v", i, err)
 			continue
@@ -589,7 +589,7 @@ func TestAppendHuffmanString(t *testing.T) {
 	}
 	for i, tt := range tests {
 		buf := []byte{}
-		want := strings.Replace(tt.want, " ", "", -1)
+		want := strings.ReplaceAll(tt.want, " ", "")
 		buf = AppendHuffmanString(buf, tt.in)
 		if got := hex.EncodeToString(buf); want != got {
 			t.Errorf("%d. encode = %q; want %q", i, got, want)
@@ -758,8 +758,8 @@ func TestHuffmanFuzzCrash(t *testing.T) {
 }
 
 func dehex(s string) []byte {
-	s = strings.Replace(s, " ", "", -1)
-	s = strings.Replace(s, "\n", "", -1)
+	s = strings.ReplaceAll(s, " ", "")
+	s = strings.ReplaceAll(s, "\n", "")
 	b, err := hex.DecodeString(s)
 	if err != nil {
 		panic(err)

--- a/bfe_net/textproto/reader_test.go
+++ b/bfe_net/textproto/reader_test.go
@@ -288,7 +288,7 @@ func TestCommonHeaders(t *testing.T) {
 	}
 }
 
-var clientHeaders = strings.Replace(`Host: golang.org
+var clientHeaders = strings.ReplaceAll(`Host: golang.org
 Connection: keep-alive
 Cache-Control: max-age=0
 Accept: application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
@@ -299,9 +299,9 @@ Accept-Charset: ISO-8859-1,utf-8;q=0.7,*;q=0.3
 COOKIE: __utma=000000000.0000000000.0000000000.0000000000.0000000000.00; __utmb=000000000.0.00.0000000000; __utmc=000000000; __utmz=000000000.0000000000.00.0.utmcsr=code.google.com|utmccn=(referral)|utmcmd=referral|utmcct=/p/go/issues/detail
 Non-Interned: test
 
-`, "\n", "\r\n", -1)
+`, "\n", "\r\n")
 
-var serverHeaders = strings.Replace(`Content-Type: text/html; charset=utf-8
+var serverHeaders = strings.ReplaceAll(`Content-Type: text/html; charset=utf-8
 Content-Encoding: gzip
 Date: Thu, 27 Sep 2012 09:03:33 GMT
 Server: Google Frontend
@@ -311,7 +311,7 @@ VIA: 1.1 proxy.example.com:80 (XXX/n.n.n-nnn)
 Connection: Close
 Non-Interned: test
 
-`, "\n", "\r\n", -1)
+`, "\n", "\r\n")
 
 func BenchmarkReadMIMEHeader(b *testing.B) {
 	b.ReportAllocs()


### PR DESCRIPTION
Replace `strings.Replace(s, old, new, -1)` with `strings.ReplaceAll(s, old, new)`. `strings.ReplaceAll` is a wrapper function for `strings.Replace`, but `strings.ReplaceAll` is more readable and removes the hardcoded `-1`.