### PR TITLE
make sure the buff can be written

### DIFF
--- a/bfe_bufio/bufio.go
+++ b/bfe_bufio/bufio.go
@@ -107,7 +107,10 @@ func (b *Reader) fill() {
 		b.w -= b.r
 		b.r = 0
 	}
-
+	// make sure the buff can be written
+	if b.w >= len(b.buf) {
+		return
+	}
 	// Read new data.
 	n, err := b.rd.Read(b.buf[b.w:])
 	if n < 0 {


### PR DESCRIPTION
at the same time, I think the following codes don't make sense:
```
if (b.w + n) > len(b.buf) {
	log.Logger.Warn("bfe_bufio:reader.fill(),len(buf)=%d,b.r=%d,b.w=%d,n=%d\n",
			len(b.buf), b.r, b.w, n
}
```
theoretically, b.w+n <= len(b.buf). when b.w+n can be > len(b.buf)?
