### PR TITLE
fix some unreachable code

### DIFF
--- a/bfe_basic/condition/primitive_test.go
+++ b/bfe_basic/condition/primitive_test.go
@@ -234,7 +234,6 @@ func TestContextValueFetcher(t *testing.T) {
 	contextVal, err := hf.Fetch(req)
 	if err != nil {
 		t.Fatalf("Fetch(): %v", err)
-		t.FailNow()
 	}
 
 	// check

--- a/bfe_http2/server_test.go
+++ b/bfe_http2/server_test.go
@@ -3000,7 +3000,6 @@ func TestNoRstPostAfterGOAWAY(t *testing.T) {
 		}
 		if gf, ok := f.(*RSTStreamFrame); ok && gf.StreamID == 1 {
 			t.Fatal("got rst but want no ret")
-			break
 		}
 	}
 


### PR DESCRIPTION
Signed-off-by: Abirdcfly <fp544037857@gmail.com>

see https://go.dev/play/p/8fS-lKgH7Ze for example:
```go
package main

import (
	"fmt"
	"testing"
	"time"
)

func TestA(t *testing.T) {
	errc := make(chan error, 1)
	donec := make(chan bool)

	go func() {
		defer close(donec)
		time.Sleep(time.Second)
		// time.Sleep(10 * time.Second) // or you want test with timeout.
	}()

	select {
	case <-donec:
		fmt.Println("just return")
		return
	case <-time.After(5 * time.Second):
		t.Fatal("timeout")
	}
	fmt.Println("cant reach!!!")
	e := fmt.Errorf("err one")
	errc <- e
	select {
	case err := <-errc:
		if err != nil {
			t.Fatalf("Error in handler: %v", err)
		}
	case <-time.After(2 * time.Second):
		t.Error("timeout waiting for handler to finish")
	}
}

/* 
// Output:
=== RUN   TestA
just return
--- PASS: TestA (1.00s)
PASS

Program exited.

// Output when uncommenting line 16 and letting the program time out:
=== RUN   TestA
    prog.go:24: timeout
--- FAIL: TestA (5.00s)
FAIL

Program exited.
*/

```