### PR TITLE
remove TestSetKeepAlive

### DIFF
--- a/bfe_modules/mod_tcp_keepalive/mod_tcp_keepalive_test.go
+++ b/bfe_modules/mod_tcp_keepalive/mod_tcp_keepalive_test.go
@@ -15,7 +15,6 @@
 package mod_tcp_keepalive
 
 import (
-	"net"
 	"testing"
 
 	"github.com/baidu/go-lib/web-monitor/web_monitor"

--- a/bfe_modules/mod_tcp_keepalive/mod_tcp_keepalive_test.go
+++ b/bfe_modules/mod_tcp_keepalive/mod_tcp_keepalive_test.go
@@ -38,40 +38,6 @@ func prepareRequest() *bfe_basic.Request {
 	return request
 }
 
-func TestSetKeepAlive(t *testing.T) {
-	m, err := prepareModule()
-	if err != nil {
-		t.Errorf("prepareModule() error: %v", err)
-		return
-	}
-	s := new(bfe_basic.Session)
-	ip := "180.97.93.196"
-	address := "180.97.93.196:80"
-
-	s.Product = "product1"
-	s.Vip = net.ParseIP(ip)
-	if s.Vip == nil {
-		t.Errorf("net.ParseIP(%s) == nil", ip)
-	}
-
-	conn, err := net.Dial("tcp", address)
-	if err != nil {
-		t.Errorf("net.Dial(tcp, %s) error: %v", address, err)
-		return
-	}
-	s.Connection = conn
-
-	m.HandleAccept(s)
-	metrics := m.metrics.GetAll()
-	if metrics.CounterData["CONN_TO_SET"] != 1 ||
-		metrics.CounterData["CONN_SET_KEEP_IDLE"] != 1 ||
-		metrics.CounterData["CONN_SET_KEEP_INTVL"] != 1 {
-
-		t.Errorf("CONN_TO_SET and CONN_SET_KEEP_IDLE and CONN_SET_KEEP_INTVL should be 1")
-		return
-	}
-}
-
 func TestModuleMisc(t *testing.T) {
 	m, err := prepareModule()
 	if err != nil {

--- a/bfe_modules/mod_tcp_keepalive/mod_tcp_keepalive_test.go
+++ b/bfe_modules/mod_tcp_keepalive/mod_tcp_keepalive_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/baidu/go-lib/web-monitor/web_monitor"
+
 	"github.com/bfenetworks/bfe/bfe_basic"
 	"github.com/bfenetworks/bfe/bfe_http"
 	"github.com/bfenetworks/bfe/bfe_module"

--- a/bfe_modules/mod_tcp_keepalive/mod_tcp_keepalive_test.go
+++ b/bfe_modules/mod_tcp_keepalive/mod_tcp_keepalive_test.go
@@ -18,7 +18,6 @@ import (
 	"testing"
 
 	"github.com/baidu/go-lib/web-monitor/web_monitor"
-
 	"github.com/bfenetworks/bfe/bfe_basic"
 	"github.com/bfenetworks/bfe/bfe_http"
 	"github.com/bfenetworks/bfe/bfe_module"


### PR DESCRIPTION
- This unit test uses an external IP for testing.
- The service at this IP is not stable, and recently, frequent unresponsiveness has resulted in compilation failures.
- Unit tests should not rely on external services.