### PR TITLE
fix: correct ai token auth default rule path

### DIFF
--- a/bfe_modules/mod_ai_token_auth/conf_mod_ai_token_auth.go
+++ b/bfe_modules/mod_ai_token_auth/conf_mod_ai_token_auth.go
@@ -54,7 +54,7 @@ type ConfModAITokenAuth struct {
 func (cfg *ConfModAITokenAuth) Check(confRoot string) error {
 	if cfg.Basic.ProductRulePath == "" {
 		log.Logger.Warn("ModAITokenAuth.ProductRulePath not set, use default value")
-		cfg.Basic.ProductRulePath = "mod_ai_toekn_auth/token_rule.data"
+		cfg.Basic.ProductRulePath = "mod_ai_token_auth/token_rule.data"
 	}
 
 	cfg.Basic.ProductRulePath = bfe_util.ConfPathProc(cfg.Basic.ProductRulePath, confRoot)

--- a/bfe_modules/mod_ai_token_auth/conf_mod_ai_token_auth_test.go
+++ b/bfe_modules/mod_ai_token_auth/conf_mod_ai_token_auth_test.go
@@ -1,0 +1,34 @@
+// Copyright (c) 2025 The BFE Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mod_ai_token_auth
+
+import "testing"
+
+func TestConfModAITokenAuthCheckDefaultProductRulePath(t *testing.T) {
+	cfg := &ConfModAITokenAuth{}
+	cfg.Redis.Bns = "BFE.poc-redis-wx"
+	cfg.Redis.ConnectTimeout = 20
+	cfg.Redis.ReadTimeout = 20
+	cfg.Redis.WriteTimeout = 20
+
+	if err := cfg.Check("conf"); err != nil {
+		t.Fatalf("ConfModAITokenAuth.Check() error = %v", err)
+	}
+
+	want := "conf/mod_ai_token_auth/token_rule.data"
+	if cfg.Basic.ProductRulePath != want {
+		t.Fatalf("ProductRulePath = %s, want %s", cfg.Basic.ProductRulePath, want)
+	}
+}


### PR DESCRIPTION
## What
Fixes the default ProductRulePath for `mod_ai_token_auth`.

It pointed at `mod_ai_toekn_auth/token_rule.data`, so leaving the setting empty sends BFE to a dead config path. tiny typo, real footgun imo.

## Repro
1. Leave `[basic].ProductRulePath` empty in `conf/mod_ai_token_auth/mod_ai_token_auth.conf`.
2. Run config check/init.
3. Before: resolves to `conf/mod_ai_toekn_auth/token_rule.data`.
4. After: resolves to `conf/mod_ai_token_auth/token_rule.data`.

No cloud quota / API limit angle here, this is plain config fallback logic and it is reachable in normal deployments.

## Tests
- `go test -count=1 ./bfe_modules/mod_ai_token_auth`
- `go test ./...`

No matching issue/PR found, afaict.