### PR TITLE
Add CONF_AGENT_REPO argument to Dockerfile and Makefile for configura…

### DIFF
--- a/.licenserc.yaml
+++ b/.licenserc.yaml
@@ -25,7 +25,7 @@ header:
     - '**/go.sum'
     - '**/*.md'
     - '**/testdata/*'
-    - '**/test_data/*/**'
+    - '**/test_data/**'
     - '**/*/testdata/*/**'
     - 'LICENSE'
     - 'NOTICE'

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ RUN set -ex; \
 FROM alpine:3.19 AS confagent
 ARG TARGETARCH
 ARG CONF_AGENT_VERSION=0.0.2
+ARG CONF_AGENT_REPO=bfenetworks
 
 RUN apk add --no-cache ca-certificates wget tar
 
@@ -44,7 +45,7 @@ RUN set -ex; \
 		arm64|aarch64) CONF_AGENT_ARCH="arm64" ;; \
 		*) echo "Unsupported architecture: ${ARCH}"; exit 1 ;; \
 	esac; \
-	CONF_AGENT_URL="https://github.com/bfenetworks/conf-agent/releases/download/${CONF_AGENT_VERSION_TAG}/conf-agent_${CONF_AGENT_VERSION_NO_V}_linux_${CONF_AGENT_ARCH}.tar.gz"; \
+	CONF_AGENT_URL="https://github.com/${CONF_AGENT_REPO}/conf-agent/releases/download/${CONF_AGENT_VERSION_TAG}/conf-agent_${CONF_AGENT_VERSION_NO_V}_linux_${CONF_AGENT_ARCH}.tar.gz"; \
 	wget -O /tmp/conf-agent.tar.gz "${CONF_AGENT_URL}"; \
 	tar -xzf /tmp/conf-agent.tar.gz -C /tmp; \
 	mkdir -p /out; \

--- a/Makefile
+++ b/Makefile
@@ -74,8 +74,7 @@ strip: prepare compile-strip package
 # make prepare, download dependencies
 prepare: prepare-dep prepare-gen
 prepare-dep:
-#	$(call INSTALL_PKG, goyacc, golang.org/x/tools/cmd/goyacc@latest)
-	$(call INSTALL_PKG, goyacc, golang.org/x/tools/cmd/goyacc@v0.27.0)
+	$(call INSTALL_PKG, goyacc, golang.org/x/tools/cmd/goyacc@latest)
 prepare-gen:
 	cd "bfe_basic/condition/parser" && $(GOGEN)
 
@@ -146,6 +145,7 @@ BFE_IMAGE_NAME ?= bfe
 # Default: 0.0.2
 # Override example: make docker CONF_AGENT_VERSION=0.0.2
 CONF_AGENT_VERSION ?= 0.0.2
+CONF_AGENT_REPO ?= bfenetworks
 NO_CACHE ?= false
 
 # Optional cleanup controls
@@ -186,6 +186,7 @@ docker:
 		$$(if [ "$(NO_CACHE)" = "true" ]; then echo "--no-cache"; fi) \
 		--build-arg VARIANT=prod \
 		--build-arg CONF_AGENT_VERSION=$$NORM_CONF_VERSION \
+		--build-arg CONF_AGENT_REPO=$(CONF_AGENT_REPO) \
 		-t $(BFE_IMAGE_NAME):$$NORM_BFE_VERSION \
 		-t $(BFE_IMAGE_NAME):latest \
 		-f Dockerfile \
@@ -195,6 +196,7 @@ docker:
 		$$(if [ "$(NO_CACHE)" = "true" ]; then echo "--no-cache"; fi) \
 		--build-arg VARIANT=debug \
 		--build-arg CONF_AGENT_VERSION=$$NORM_CONF_VERSION \
+		--build-arg CONF_AGENT_REPO=$(CONF_AGENT_REPO) \
 		-t $(BFE_IMAGE_NAME):$$NORM_BFE_VERSION-debug \
 		-f Dockerfile \
 		.
@@ -233,6 +235,7 @@ docker-push:
 		$$NO_CACHE_OPT \
 		--build-arg VARIANT=prod \
 		--build-arg CONF_AGENT_VERSION=$$NORM_CONF_VERSION \
+		--build-arg CONF_AGENT_REPO=$(CONF_AGENT_REPO) \
 		-t $(REGISTRY)/$(BFE_IMAGE_NAME):$$NORM_BFE_VERSION \
 		-t $(REGISTRY)/$(BFE_IMAGE_NAME):latest \
 		-f Dockerfile \
@@ -244,6 +247,7 @@ docker-push:
 		$$NO_CACHE_OPT \
 		--build-arg VARIANT=debug \
 		--build-arg CONF_AGENT_VERSION=$$NORM_CONF_VERSION \
+		--build-arg CONF_AGENT_REPO=$(CONF_AGENT_REPO) \
 		-t $(REGISTRY)/$(BFE_IMAGE_NAME):$$NORM_BFE_VERSION-debug \
 		-f Dockerfile \
 		--push \


### PR DESCRIPTION
Add CONF_AGENT_REPO argument to Dockerfile and Makefile to support configurable repository sources for the conf-agent component. This change enables packaging the image with alternative repository origins, improving flexibility in different environments.