### PR TITLE
fix: pin goyacc version to v0.27.0 in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ strip: prepare compile-strip package
 # make prepare, download dependencies
 prepare: prepare-dep prepare-gen
 prepare-dep:
-	$(call INSTALL_PKG, goyacc, golang.org/x/tools/cmd/goyacc@latest)
+	$(call INSTALL_PKG, goyacc, golang.org/x/tools/cmd/goyacc@v0.27.0)
 prepare-gen:
 	cd "bfe_basic/condition/parser" && $(GOGEN)
 


### PR DESCRIPTION
fix goyacc version to v0.27.0