### PR TITLE
fix(mod_unified_waf): fix data race on openDebug

### DIFF
--- a/bfe_modules/mod_unified_waf/mod_unified_waf.go
+++ b/bfe_modules/mod_unified_waf/mod_unified_waf.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"sync/atomic"
 	"time"
 
 	"github.com/bfenetworks/go-lib/log"
@@ -69,9 +70,7 @@ var COUNTER_KEYS = []string{
 	bfe_basic.NET_ERR,
 }
 
-var (
-	openDebug = false
-)
+var openDebug atomic.Bool
 
 type ModuleWaf struct {
 	name          string // name of module
@@ -124,8 +123,8 @@ func (m *ModuleWaf) Init(cbs *bfe_module.BfeCallbacks, whs *web_monitor.WebHandl
 	}
 
 	// set debug switch
-	openDebug = m.conf.Log.OpenDebug
-	if openDebug {
+	openDebug.Store(m.conf.Log.OpenDebug)
+	if openDebug.Load() {
 		log.Logger.Debug("mod_unified_waf openDebug")
 	}
 
@@ -347,7 +346,7 @@ func (m *ModuleWaf) wafHandler(req *bfe_basic.Request) (int, *bfe_http.Response)
 	conf := m.getRequestWafParam(req)
 	// no waf check
 	if conf == nil {
-		if openDebug {
+		if openDebug.Load() {
 			log.Logger.Debug("product %s has no waf config", req.Route.Product)
 		}
 
@@ -446,7 +445,7 @@ func (m *ModuleWaf) genWafRequest(req *bfe_basic.Request, param *WafParam, delay
 			wafRequest.Body = ioutil.NopCloser(bytes.NewReader(b))
 			wafBodySize = int64(len(b))
 			wafRequest.ContentLength = wafBodySize
-			if openDebug {
+			if openDebug.Load() {
 				log.Logger.Info("mod_unified_waf Peek succ, %d, contentlen:%d", peekN, wafBodySize)
 			}
 		} else {

--- a/bfe_modules/mod_unified_waf/waf_client.go
+++ b/bfe_modules/mod_unified_waf/waf_client.go
@@ -153,7 +153,7 @@ func (c *WafClient) Detect(req *bfe_basic.Request, wafReq *http.Request, param *
 		c.monitor.state.Inc(bfe_basic.REQ_NO_CHECK, 1)
 		c.monitor.state.Inc("waf_client_detect_closed_skip_"+c.serverAddress, 1)
 		setWafStatus(req, (int)(bfe_basic.WAF_NO_CHECK))
-		if openDebug {
+		if openDebug.Load() {
 			log.Logger.Debug("waf instance is closed, but skip, instance = %s, logid = %s",
 				c.serverAddress, req.LogId)
 		}
@@ -171,7 +171,7 @@ func (c *WafClient) Detect(req *bfe_basic.Request, wafReq *http.Request, param *
 		setWafStatus(req, (int)(bfe_basic.WAF_TIMEOUT))
 		setWafSpentTime(req, startTime, endTime)
 
-		if openDebug {
+		if openDebug.Load() {
 			log.Logger.Debug("time out for concurrency control, logid = %s, start = %d, end = %d",
 				req.LogId, startTime.UnixNano(), endTime.UnixNano())
 		}
@@ -219,7 +219,7 @@ func (c *WafClient) Detect(req *bfe_basic.Request, wafReq *http.Request, param *
 			setWafRuleName(req, "-")
 			req.ErrCode = ERR_WAF_FORBIDDEN
 
-			if openDebug {
+			if openDebug.Load() {
 				log.Logger.Debug("waf-server detect block, logid = %s, start = %d, end = %d",
 					req.LogId, startTime.UnixNano(), endTime.UnixNano())
 			}
@@ -235,7 +235,7 @@ func (c *WafClient) Detect(req *bfe_basic.Request, wafReq *http.Request, param *
 		setWafStatus(req, int(bfe_basic.WAF_PASS))
 
 		// pass, go on
-		if openDebug {
+		if openDebug.Load() {
 			log.Logger.Debug("waf-server detect pass, logid = %s, start = %d, end = %d",
 				req.LogId, startTime.UnixNano(), endTime.UnixNano())
 		}
@@ -249,7 +249,7 @@ func (c *WafClient) Detect(req *bfe_basic.Request, wafReq *http.Request, param *
 		setWafStatus(req, (int)(bfe_basic.WAF_TIMEOUT))
 		setWafSpentTime(req, startTime, endTime)
 
-		if openDebug {
+		if openDebug.Load() {
 			log.Logger.Debug("time out for waiting waf-server, logid = %s, start = %d, end = %d",
 				req.LogId, startTime.UnixNano(), endTime.UnixNano())
 		}
@@ -275,7 +275,7 @@ func (c *WafClient) getToken(req *bfe_basic.Request, reqTimeout time.Duration, l
 		ok = false
 	}
 
-	if ok && openDebug {
+	if ok && openDebug.Load() {
 		log.Logger.Debug("get concurrencyChan, logid = %s", logId)
 	}
 
@@ -293,7 +293,7 @@ func (c *WafClient) detect(req *http.Request, done chan *WafDetectResult, retryM
 	defer func() {
 		// release
 		c.concurrencyChan <- 1
-		if openDebug {
+		if openDebug.Load() {
 			log.Logger.Debug("release concurrencyChan, logid = %s", logId)
 		}
 		if err := recover(); err != nil {
@@ -310,7 +310,7 @@ func (c *WafClient) detect(req *http.Request, done chan *WafDetectResult, retryM
 			break
 		}
 
-		if openDebug {
+		if openDebug.Load() {
 			log.Logger.Debug("c.client.Detect(dc) failed: %s, retry = %d, logid = %s", err.Error(), i, logId)
 		}
 		c.instanceHeathJudge(false, false)
@@ -318,7 +318,7 @@ func (c *WafClient) detect(req *http.Request, done chan *WafDetectResult, retryM
 
 	// send result
 	done <- &WafDetectResult{Result: res, Error: err}
-	if openDebug {
+	if openDebug.Load() {
 		log.Logger.Debug("waf detect done, logid = %s", logId)
 	}
 }


### PR DESCRIPTION
Use sync/atomic.Bool instead of plain bool for package-level openDebug, so concurrent reads from WafClient.detect goroutines and writes from ModuleWaf.Init() are properly synchronized. This fixes go test -race failures in mod_unified_waf.