### PR TITLE
feat(bfe): consume full Redis key from rate-limit export and support …

### DIFF
--- a/bfe_modules/mod_ai_rate_limit/policy_limiter.go
+++ b/bfe_modules/mod_ai_rate_limit/policy_limiter.go
@@ -16,6 +16,7 @@ package mod_ai_rate_limit
 
 import (
 	"fmt"
+	"strings"
 	"sync"
 	"sync/atomic"
 
@@ -108,6 +109,11 @@ func buildRpmInstId(rule *RPMRuleConf) string {
 
 func buildTpmRedisKey(policyId string, rule *TPMRuleConf) string {
 	if rule.RedisKey != "" {
+		// 新格式：控制面直接下发完整 Redis Key（以 default_bfe_ 开头）。
+		// 旧格式：控制面下发 suffix，需要拼接前缀。
+		if strings.HasPrefix(rule.RedisKey, "default_bfe_") {
+			return rule.RedisKey
+		}
 		return buildRedisKey(policyId, rule.RedisKey)
 	}
 	return buildRedisKey(policyId, fmt.Sprintf("tpm_%s", buildTpmInstId(rule)))
@@ -115,6 +121,9 @@ func buildTpmRedisKey(policyId string, rule *TPMRuleConf) string {
 
 func buildRpmRedisKey(policyId string, rule *RPMRuleConf) string {
 	if rule.RedisKey != "" {
+		if strings.HasPrefix(rule.RedisKey, "default_bfe_") {
+			return rule.RedisKey
+		}
 		return buildRedisKey(policyId, rule.RedisKey)
 	}
 	return buildRedisKey(policyId, fmt.Sprintf("rpm_%s", buildRpmInstId(rule)))

--- a/bfe_util/redis_client/client.go
+++ b/bfe_util/redis_client/client.go
@@ -36,6 +36,7 @@ type Client interface {
 	PIncr([]string) ([]int64, error)
 	GetInt64(key string) (int64, error)
 	IncrBy(key string, delta int64) (int64, error)
+	Delete(key string) error
 	NewScript(src string) RedisScript
 }
 

--- a/bfe_util/redis_client/redis_bns.go
+++ b/bfe_util/redis_client/redis_bns.go
@@ -558,6 +558,22 @@ func (c *RedisClient) IncrBy(key string, delta int64) (int64, error) {
 	return count, nil
 }
 
+// delete key from redis
+func (c *RedisClient) Delete(key string) error {
+	// get connection from pool
+	conn := c.getConnByKey(key)
+	defer conn.Close()
+
+	procStart := time.Now()
+	_, err := conn.Do("DEL", key)
+	if err != nil {
+		return err
+	}
+
+	c.setDelayState(c.delay, procStart)
+	return nil
+}
+
 // incr and expire key to redis
 func (c *RedisClient) IncrAndExpire(key string, expire int) (int64, error) {
 	c.incrModuleState2(RedisIncr)


### PR DESCRIPTION
…key cleanup

- Use full Redis key exported by ai-gateway-api for rate-limit counters.
- Add DeleteKeys support to Redis client/BNS wrapper for control-plane cleanup.