### PR TITLE
fix(mod_ai_token_auth): allow zero total_token quota and treat missin…

### DIFF
--- a/bfe_modules/mod_ai_token_auth/mod_ai_token_auth_test.go
+++ b/bfe_modules/mod_ai_token_auth/mod_ai_token_auth_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/bfenetworks/bfe/bfe_route/bfe_cluster"
 	"github.com/bfenetworks/bfe/bfe_util/redis_client"
 	"github.com/bfenetworks/go-lib/quota"
+	"github.com/gomodule/redigo/redis"
 )
 
 const testConfRoot = "testdata/mod_ai_token_auth"
@@ -1508,6 +1509,11 @@ func TestQuotaPlanCheck(t *testing.T) {
 		t.Errorf("valid quota plan failed: %s", err)
 	}
 
+	zeroQuota := QuotaPlan{Id: "p1", Unlimited: false, Quota: 0, Unit: "total_token", ExpiredTime: -1}
+	if err := quotaPlanCheck(&zeroQuota); err != nil {
+		t.Errorf("zero quota plan should be allowed: %s", err)
+	}
+
 	cases := []struct {
 		name string
 		plan QuotaPlan
@@ -1515,7 +1521,7 @@ func TestQuotaPlanCheck(t *testing.T) {
 	}{
 		{"missing id", QuotaPlan{Unlimited: true}, "no Id"},
 		{"invalid expired time", QuotaPlan{Id: "p1", Unlimited: true, ExpiredTime: -2}, "invalid ExpiredTime"},
-		{"invalid token quota", QuotaPlan{Id: "p1", Unlimited: false, Quota: 0, Unit: "total_token"}, "invalid Quota"},
+		{"invalid token quota", QuotaPlan{Id: "p1", Unlimited: false, Quota: -1, Unit: "total_token"}, "invalid Quota"},
 		{"invalid rmb quota", QuotaPlan{Id: "p1", Unlimited: false, Quota: -1, Unit: "RMB"}, "invalid Quota for RMB"},
 		{"invalid unit", QuotaPlan{Id: "p1", Unlimited: true, Unit: "invalid"}, "invalid Unit"},
 	}
@@ -1614,7 +1620,7 @@ func (m *mockRedisClient) GetInt64(key string) (int64, error) {
 	if v, ok := m.data[key]; ok {
 		return v, nil
 	}
-	return 0, fmt.Errorf("key not found")
+	return 0, redis.ErrNil
 }
 
 func (m *mockRedisClient) GetInt64Batch(keys []string) ([]int64, error) {
@@ -1731,6 +1737,52 @@ func TestQuotaPlanDeduct(t *testing.T) {
 		}
 		if remaining != 10000 {
 			t.Errorf("remaining = %d, want 10000", remaining)
+		}
+	})
+}
+
+func TestQuotaPlanHasBalance(t *testing.T) {
+	t.Run("missing key means no balance", func(t *testing.T) {
+		client := newMockRedisClient()
+		plan := &QuotaPlan{Id: "p1", RedisKey: "absent-key", Unit: "total_token", Quota: 0}
+		has, remaining, err := plan.HasBalance(client)
+		if err != nil {
+			t.Fatalf("HasBalance failed: %v", err)
+		}
+		if has {
+			t.Error("expected no balance for missing key")
+		}
+		if remaining != 0 {
+			t.Errorf("remaining = %d, want 0", remaining)
+		}
+	})
+
+	t.Run("zero balance", func(t *testing.T) {
+		client := newMockRedisClient()
+		client.data["zero-key"] = 0
+		plan := &QuotaPlan{Id: "p1", RedisKey: "zero-key", Unit: "total_token", Quota: 0}
+		has, _, err := plan.HasBalance(client)
+		if err != nil {
+			t.Fatalf("HasBalance failed: %v", err)
+		}
+		if has {
+			t.Error("expected no balance for zero value")
+		}
+	})
+
+	t.Run("positive balance", func(t *testing.T) {
+		client := newMockRedisClient()
+		client.data["pos-key"] = 50
+		plan := &QuotaPlan{Id: "p1", RedisKey: "pos-key", Unit: "total_token", Quota: 100}
+		has, remaining, err := plan.HasBalance(client)
+		if err != nil {
+			t.Fatalf("HasBalance failed: %v", err)
+		}
+		if !has {
+			t.Error("expected balance for positive value")
+		}
+		if remaining != 50 {
+			t.Errorf("remaining = %d, want 50", remaining)
 		}
 	})
 }

--- a/bfe_modules/mod_ai_token_auth/token.go
+++ b/bfe_modules/mod_ai_token_auth/token.go
@@ -156,6 +156,11 @@ func (q *QuotaPlan) HasBalance(client redis_client.Client) (bool, int64, error) 
 
 	current, err := client.GetInt64(q.RedisKey)
 	if err != nil {
+		// key not initialized (e.g. quota set to 0 and never synced to redis)
+		// means no balance, not an internal error
+		if redis_client.IsKeyNotFound(err) {
+			return false, 0, nil
+		}
 		return false, 0, err
 	}
 

--- a/bfe_modules/mod_ai_token_auth/token_rule_load.go
+++ b/bfe_modules/mod_ai_token_auth/token_rule_load.go
@@ -138,7 +138,9 @@ func quotaPlanCheck(conf *QuotaPlan) error {
 				return fmt.Errorf("invalid Quota for RMB: %d", conf.Quota)
 			}
 		} else {
-			if conf.Quota <= 0 {
+			// quota 0 is allowed: it means the plan has no balance and
+			// requests bound to it will be rejected with QuotaExhausted
+			if conf.Quota < 0 {
 				return fmt.Errorf("invalid Quota: %d", conf.Quota)
 			}
 		}

--- a/bfe_util/redis_client/client.go
+++ b/bfe_util/redis_client/client.go
@@ -15,7 +15,10 @@
 package redis_client
 
 import (
+	"errors"
 	"fmt"
+
+	"github.com/gomodule/redigo/redis"
 )
 
 type RedisScript interface {
@@ -23,6 +26,11 @@ type RedisScript interface {
 		key string,
 		args ...interface{},
 	) (interface{}, error)
+}
+
+// IsKeyNotFound reports whether err indicates the redis key does not exist.
+func IsKeyNotFound(err error) bool {
+	return errors.Is(err, redis.ErrNil)
 }
 
 // Client: redis client interface

--- a/docs/en_us/configuration/mod_ai_token_auth/token_rule.data.md
+++ b/docs/en_us/configuration/mod_ai_token_auth/token_rule.data.md
@@ -19,7 +19,7 @@
 | QuotaPlans{v}[].redis_key | String | Redis key for storing quota | N | Optional when `unlimited` is true | - |
 | QuotaPlans{v}[].create_time | Integer | Create time (Unix Time) | N | - | - |
 | QuotaPlans{v}[].expired_time | Integer | Expiry time (Unix Time) | N | `-1` means never expires | Must be greater than or equal to `-1` |
-| QuotaPlans{v}[].quota | Integer | Total quota | N | Unit is determined by the `unit` field; when `unit=RMB`, this is a fixed-point integer with precision `1e-8` yuan; required when `unlimited` is false | Must be greater than 0 when `unit=total_token` and `unlimited` is false; must be greater than or equal to 0 when `unit=RMB` and `unlimited` is false |
+| QuotaPlans{v}[].quota | Integer | Total quota | N | Unit is determined by the `unit` field; when `unit=RMB`, this is a fixed-point integer with precision `1e-8` yuan; required when `unlimited` is false | Must be greater than or equal to 0 when `unlimited` is false; when `unit=total_token`, `quota=0` means the plan has no balance and requests bound to it are rejected with `QuotaExhausted` |
 | QuotaPlans{v}[].reset_mode | Integer | Reset mode | Y | `0` - non-periodic; `1` - periodic quota package | Value must be `0` or `1` |
 | QuotaPlans{v}[].unit | String | Quota unit | N | Defaults to `total_token` | Value must be `total_token` or `RMB` |
 | Tokens | Object | API-key declarations for all product lines | Y | Key is product line name | - |
@@ -115,3 +115,4 @@
 > Note:
 > - When `unit = total_token`, `quota` is an integer number of tokens.
 > - When `unit = RMB`, `quota` is a fixed-point integer with precision `1e-8` yuan (i.e., 1 unit = 0.00000001 yuan). For example, `90000000` means `0.9` yuan.
+> - When `unlimited` is false, `quota` must be greater than or equal to 0. A `quota` of 0 means the plan has no balance; requests bound to such a plan are rejected with `QuotaExhausted` (HTTP 429).

--- a/docs/zh_cn/configuration/mod_ai_token_auth/token_rule.data.md
+++ b/docs/zh_cn/configuration/mod_ai_token_auth/token_rule.data.md
@@ -51,7 +51,7 @@
 | PassNoQuota | bool | Y | 配额不足时是否放行；为 `true` 时跳过该计划的余额检查 | - |
 | RedisKey | string | N | Redis 中存储配额余额的 Key | `Unlimited` 为 `false` 时必须有有效值，否则运行时扣减/校验余额会失败 |
 | ExpiredTime | int64 | N | 过期时间；`-1` 表示永不过期 | 必须大于等于 `-1` |
-| Quota | int64 | N | 配额总量 | `Unit=total_token` 且 `Unlimited=false` 时必须大于 0；`Unit=RMB` 且 `Unlimited=false` 时必须大于等于 0 |
+| Quota | int64 | N | 配额总量 | `Unlimited=false` 时必须大于等于 0；`Unit=total_token` 时 `Quota=0` 表示无余额，绑定该计划的请求将被拒绝（`QuotaExhausted`） |
 | Unit | string | N | 配额单位 | `total_token` 或 `RMB`；为空时默认 `total_token` |
 
 ## 4. Tokens 结构（api-key 声明）

--- a/docs/zh_cn/sys_design/rmb_quota.md
+++ b/docs/zh_cn/sys_design/rmb_quota.md
@@ -319,7 +319,7 @@ type QuotaPlan struct {
 `quotaPlanCheck` 需要调整：
 
 - `Unit` 为空时默认 `"total_token"`，保持兼容。
-- `Unit = "total_token"`：`Unlimited=false` 时 `Quota > 0`。
+- `Unit = "total_token"`：`Unlimited=false` 时 `Quota >= 0`；`Quota = 0` 表示该计划无余额，绑定它的请求将被拒绝（`QuotaExhausted`）。
 - `Unit = "RMB"`：`Unlimited=false` 时 `Quota >= 0`。
 
 ### 6.4 `AiBasicInfo` 请求完成状态

--- a/tests/integration/implementation/scenario-SC03-rmb-quota/sc03_rmb_quota_test.go
+++ b/tests/integration/implementation/scenario-SC03-rmb-quota/sc03_rmb_quota_test.go
@@ -771,3 +771,59 @@ func TestTC12_RMBQuotaDeduction_ImageGeneration(t *testing.T) {
 		t.Fatalf("remaining quota = %d, want %d, response body: %s", remaining, want, body)
 	}
 }
+
+
+// TestTC13 verifies that a total_token quota plan with quota=0 can be loaded
+// and rejects requests with QuotaExhausted.
+func TestTC13_TokenQuotaZeroLoaded(t *testing.T) {
+	aiConfs := map[string]*cluster_conf.AIConf{
+		clusterRMB: defaultRMBAIConf(),
+	}
+	e := newTestEnv(t, aiConfs, []common.QuotaPlan{tokenQuotaPlan(0)})
+	defer e.Close()
+
+	e.redis.SetQuota(redisKeyToken, 0)
+
+	resp, body, err := e.sendRequest(apiHost, defaultBody)
+	if err != nil {
+		t.Fatalf("send request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusTooManyRequests {
+		e.logBFEException()
+		t.Fatalf("expected status 429, got %d, body: %s", resp.StatusCode, body)
+	}
+	if !strings.Contains(body, "quota") {
+		t.Fatalf("expected quota error in body, got: %s", body)
+	}
+	if e.backends[clusterRMB].Hits() != 0 {
+		t.Fatalf("expected no backend hit, got %d", e.backends[clusterRMB].Hits())
+	}
+}
+
+// TestTC14 verifies that a total_token quota plan with quota=0 rejects requests
+// with QuotaExhausted even when its redis key was never initialized
+// (regression test for https://github.com/rainway-ai-gateway/ai-gateway-api/issues/136).
+func TestTC14_TokenQuotaZeroMissingRedisKey(t *testing.T) {
+	aiConfs := map[string]*cluster_conf.AIConf{
+		clusterRMB: defaultRMBAIConf(),
+	}
+	e := newTestEnv(t, aiConfs, []common.QuotaPlan{tokenQuotaPlan(0)})
+	defer e.Close()
+
+	// note: redis key redisKeyToken is intentionally not initialized
+
+	resp, body, err := e.sendRequest(apiHost, defaultBody)
+	if err != nil {
+		t.Fatalf("send request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusTooManyRequests {
+		e.logBFEException()
+		t.Fatalf("expected status 429, got %d, body: %s", resp.StatusCode, body)
+	}
+	if !strings.Contains(body, "quota") {
+		t.Fatalf("expected quota error in body, got: %s", body)
+	}
+	if e.backends[clusterRMB].Hits() != 0 {
+		t.Fatalf("expected no backend hit, got %d", e.backends[clusterRMB].Hits())
+	}
+}

--- a/tests/integration/测试设计文档/scenario-SC03-RMB配额扣减/TC-13-total_token配额为0可加载并拒绝请求.md
+++ b/tests/integration/测试设计文档/scenario-SC03-RMB配额扣减/TC-13-total_token配额为0可加载并拒绝请求.md
@@ -1,0 +1,59 @@
+# TC-13 total_token 配额为 0 可加载并拒绝请求
+
+## 用例编号与名称
+
+TC-13 total_token 配额为 0 可加载并拒绝请求
+
+## 所属场景
+
+SC03 RMB 配额扣减
+
+## 版本声明
+
+- `bfe`：当前源码版本
+
+## 测试目的
+
+验证 `Unit=total_token` 的 QuotaPlan 配置 `Quota=0` 时，`token_rule.data` 可以被 BFE 正常加载启动（回归 [ai-gateway-api#136](https://github.com/rainway-ai-gateway/ai-gateway-api/issues/136)：旧版本加载期拒绝 `Quota=0` 导致 conf-agent reload 失败），且请求在认证阶段被拒绝并返回 429 配额耗尽错误。
+
+## 运行模式
+
+单组件模式：仅启动真实 `bfe` 进程与嵌入式 Redis。
+
+## 前置条件
+
+1. 已编译 `bfe` 可执行文件。
+2. 嵌入式 Redis 已启动，并预置 `quota:plan_token = 0`。
+3. mock 后端 `cluster_rmb` 已启动（本用例不应命中）。
+4. 临时 BFE 配置已生成并加载，`cluster_rmb` 配置 `ModelTable`。
+5. `ak_user_a` 绑定 Token 配额计划 `plan_token`。
+
+## 配置构造
+
+- `plan_token`：
+  - `Unit`: `total_token`
+  - `Quota`: `0`
+  - `RedisKey`: `quota:plan_token`
+
+## BFE 请求
+
+发送 1 次 POST 请求：
+
+| 字段 | 值 |
+|------|-----|
+| Host | `rmb.example.org` |
+| Path | `/v1/chat/completions` |
+| Authorization | `Bearer ak_user_a` |
+| Body | `{"model":"deepseek-chat"}` |
+
+## 预期结果
+
+- `token_rule.data` 加载成功，BFE 正常启动监听（若加载失败，BFE 进程退出，`StartBFE` 等待端口超时，用例失败）。
+- 响应状态码：429。
+- 响应 body 中包含配额错误信息。
+- `cluster_rmb` 未被命中。
+- Redis 中 `quota:plan_token` 保持为 0。
+
+## 清理
+
+停止 `bfe` 进程、mock 后端与嵌入式 Redis，删除临时目录。

--- a/tests/integration/测试设计文档/scenario-SC03-RMB配额扣减/TC-14-total_token配额为0且RedisKey未初始化时拒绝请求.md
+++ b/tests/integration/测试设计文档/scenario-SC03-RMB配额扣减/TC-14-total_token配额为0且RedisKey未初始化时拒绝请求.md
@@ -1,0 +1,60 @@
+# TC-14 total_token 配额为 0 且 RedisKey 未初始化时拒绝请求
+
+## 用例编号与名称
+
+TC-14 total_token 配额为 0 且 RedisKey 未初始化时拒绝请求
+
+## 所属场景
+
+SC03 RMB 配额扣减
+
+## 版本声明
+
+- `bfe`：当前源码版本
+
+## 测试目的
+
+验证 `Unit=total_token` 的 QuotaPlan 配置 `Quota=0` 且 Redis 余额 key 从未初始化（key 不存在）时，BFE 在认证阶段返回 429 配额耗尽错误，而不是 500 `INTERNAL_QUOTA_ERROR`。
+
+> 背景：`QuotaPlan.HasBalance` 查询 Redis 时，key 不存在返回 `redis.ErrNil`。旧实现将 `ErrNil` 视为内部错误返回 500；修复后视为余额 0，返回 `QuotaExhausted`。本用例是该修复的回归测试。
+
+## 运行模式
+
+单组件模式：仅启动真实 `bfe` 进程与嵌入式 Redis。
+
+## 前置条件
+
+1. 已编译 `bfe` 可执行文件。
+2. 嵌入式 Redis 已启动，**不预置** `quota:plan_token`（key 不存在）。
+3. mock 后端 `cluster_rmb` 已启动（本用例不应命中）。
+4. 临时 BFE 配置已生成并加载，`cluster_rmb` 配置 `ModelTable`。
+5. `ak_user_a` 绑定 Token 配额计划 `plan_token`。
+
+## 配置构造
+
+- `plan_token`：
+  - `Unit`: `total_token`
+  - `Quota`: `0`
+  - `RedisKey`: `quota:plan_token`
+
+## BFE 请求
+
+发送 1 次 POST 请求：
+
+| 字段 | 值 |
+|------|-----|
+| Host | `rmb.example.org` |
+| Path | `/v1/chat/completions` |
+| Authorization | `Bearer ak_user_a` |
+| Body | `{"model":"deepseek-chat"}` |
+
+## 预期结果
+
+- `token_rule.data` 加载成功，BFE 正常启动监听。
+- 响应状态码：429（而非 500）。
+- 响应 body 中包含配额错误信息，不包含内部错误信息。
+- `cluster_rmb` 未被命中。
+
+## 清理
+
+停止 `bfe` 进程、mock 后端与嵌入式 Redis，删除临时目录。

--- a/tests/integration/测试设计文档/scenario-SC03-RMB配额扣减/场景说明.md
+++ b/tests/integration/测试设计文档/scenario-SC03-RMB配额扣减/场景说明.md
@@ -14,7 +14,9 @@ BFE v0.4 在 `mod_ai_token_auth` 中引入 RMB（人民币）配额支持。与 
 - fallback 到另一个 cluster 后按最终 cluster + target_model 计费；
 - 含 cache 的模型按 cache 拆分公式计费（非流式与流式）；
 - 含音频的模型按音频 input/output 拆分公式计费（非流式与流式）；
-- 图像生成模型按实际生成张数 `image_count` 与 `output_cost_per_image` 计费（非流式）。
+- 图像生成模型按实际生成张数 `image_count` 与 `output_cost_per_image` 计费（非流式）；
+- `total_token` 配额计划 `Quota=0` 的配置可以正常加载，且请求被 429 拒绝（回归 ai-gateway-api#136）；
+- `Quota=0` 且 Redis 余额 key 未初始化时，同样返回 429 配额耗尽而非 500 内部错误。
 
 > 注：TC-12 编号跳过 TC-11，是为了与后续可能补充的流式图像生成测试例预留空间。
 
@@ -251,6 +253,8 @@ BFE v0.4 在 `mod_ai_token_auth` 中引入 RMB（人民币）配额支持。与 
 | TC-09 | Audio 模型非流式计费 | 后端返回含 `audio_input_tokens` / `audio_output_tokens` 的响应，按音频拆分公式扣减 |
 | TC-10 | Audio 模型流式计费 | SSE 最终 chunk 含 audio usage，按音频拆分公式扣减 |
 | TC-12 | ImageGeneration 模型按次计费 | 请求 `/v1/images/generations`，后端返回 `usage.image_count = 2`，按 `2 * 0.03` 元扣减 |
+| TC-13 | total_token 配额为 0 可加载并拒绝请求 | `Quota=0` 的 `total_token` 计划可正常加载启动，请求返回 429 配额耗尽 |
+| TC-14 | total_token 配额为 0 且 RedisKey 未初始化时拒绝请求 | `Quota=0` 且 Redis key 不存在时返回 429 配额耗尽而非 500 内部错误 |
 
 ## 7. 公共基础设施改造
 

--- a/tests/integration/测试设计文档/测试场景总体说明.md
+++ b/tests/integration/测试设计文档/测试场景总体说明.md
@@ -25,7 +25,7 @@
 |----------|----------|------------|--------|--------------|--------------|
 | SC01 | 路由表查找与绑定 | 验证 `mod_ai_route` 在 apikey/entity/global 多级路由表中的搜索与回退顺序 | P0 | 10 | BFE 的 mod_ai_route 集成测试方案 v1.0.0 |
 | SC02 | 多 API-Key 轮换与重试 | 验证 `aiClusterInvoke()` 内部多 Key 加权选择、429 轮换、401/403 死亡、5xx 退避重试及与 cluster fallback 的边界 | P0 | 8 | BFE 多 API-Key 支持改造方案 |
-| SC03 | RMB 配额扣减 | 验证 `mod_ai_token_auth` 对 RMB 配额的定价匹配、定点数扣减、余额预检、ModelMapping/Fallback 计费行为，以及图像生成按次/图片输入 token/视频生成按次/Responses API 计费 | P0 | 11 | BFE RMB 配额支持、BFE 图像生成按次计费、BFE mode 与价格扩展 |
+| SC03 | RMB 配额扣减 | 验证 `mod_ai_token_auth` 对 RMB 配额的定价匹配、定点数扣减、余额预检、ModelMapping/Fallback 计费行为，以及图像生成按次/图片输入 token/视频生成按次/Responses API 计费 | P0 | 13 | BFE RMB 配额支持、BFE 图像生成按次计费、BFE mode 与价格扩展 |
 | SC04 | ProviderModel 前缀裁剪 | 验证 `AIConf.MatchPrefix` 与 `StripPrefix` 对请求模型名的裁剪行为 | P0 | 6 | BFE ProviderModel 前缀裁剪 |
 | SC05 | AI 访问日志字段校验 | 验证 `mod_access_pb3` 输出的 AI 可观测字段完整性与正确性，包括图像生成、视频生成、图片输入 token、Responses API 相关字段 | P0 | 14 | BFE 适配 bfe-access-pb AI 可观测字段升级、BFE 图像生成按次计费、BFE mode 与价格扩展 |
 | SC06 | Claude 协议支持 | 验证 Anthropic Claude Messages API 请求的识别、鉴权头注入、`anthropic-version` 补全及协议不匹配拒绝 | P0 | 8 | BFE Claude 协议支持 |
@@ -96,6 +96,8 @@
 | TC-09 | Audio 模型非流式计费 | P0 |
 | TC-10 | Audio 模型流式计费 | P0 |
 | TC-12 | ImageGeneration 模型按次计费 | P0 |
+| TC-13 | total_token 配额为 0 可加载并拒绝请求 | P0 |
+| TC-14 | total_token 配额为 0 且 RedisKey 未初始化时拒绝请求 | P0 |
 
 ### SC05 AI 访问日志字段校验
 


### PR DESCRIPTION
…g Redis balance as exhausted

- token_rule_load: reject only Quota < 0 so a quota plan with Quota=0 loads
- QuotaPlan.HasBalance: treat a missing Redis balance key as zero balance and return QuotaExhausted instead of a 500
- redis_client: add IsKeyNotFound helper
- add unit tests and SC03 integration cases TC-13/TC-14
- update token_rule.data docs (en_us/zh_cn) and rmb_quota.md

Relates to https://github.com/bfenetworks/bfe/issues/1348