### PR TITLE
feat(mod_ai_token_auth): keep model prices as float64 and convert per billing item

### DIFF
--- a/bfe_config/bfe_cluster_conf/cluster_conf/cluster_conf_load.go
+++ b/bfe_config/bfe_cluster_conf/cluster_conf/cluster_conf_load.go
@@ -17,9 +17,7 @@
 package cluster_conf
 
 import (
-	"bytes"
 	"crypto/x509"
-	stdjson "encoding/json"
 	"encoding/pem"
 	"errors"
 	"fmt"
@@ -168,82 +166,13 @@ type PriceTier struct {
 	TimeRanges []TimeRange // hit any range means the request belongs to this tier
 }
 
-// PriceMap is a map of price keys to their numeric values.
-// It marshals to JSON using decimal notation instead of scientific notation.
+// PriceMap is a map of price keys to their numeric values (yuan per unit).
+// Prices may use more than 8 decimal places and are serialized with the
+// default JSON encoder, which may emit scientific notation (e.g. 1.5e-6).
 type PriceMap map[string]float64
 
-// MarshalJSON serializes PriceMap using decimal notation for all values.
-func (p PriceMap) MarshalJSON() ([]byte, error) {
-	if p == nil {
-		return []byte("null"), nil
-	}
-	var buf bytes.Buffer
-	buf.WriteByte('{')
-	first := true
-	for k, v := range p {
-		if !first {
-			buf.WriteByte(',')
-		}
-		first = false
-		keyBytes, err := stdjson.Marshal(k)
-		if err != nil {
-			return nil, err
-		}
-		buf.Write(keyBytes)
-		buf.WriteByte(':')
-		buf.WriteString(strconv.FormatFloat(v, 'f', -1, 64))
-	}
-	buf.WriteByte('}')
-	return buf.Bytes(), nil
-}
-
 // TierPriceMap is a map of tier names to PriceMap values.
-// It marshals to JSON using decimal notation instead of scientific notation.
 type TierPriceMap map[string]map[string]float64
-
-// MarshalJSON serializes TierPriceMap using decimal notation for all nested values.
-func (t TierPriceMap) MarshalJSON() ([]byte, error) {
-	if t == nil {
-		return []byte("null"), nil
-	}
-	var buf bytes.Buffer
-	buf.WriteByte('{')
-	first := true
-	for tier, prices := range t {
-		if !first {
-			buf.WriteByte(',')
-		}
-		first = false
-		tierBytes, err := stdjson.Marshal(tier)
-		if err != nil {
-			return nil, err
-		}
-		buf.Write(tierBytes)
-		buf.WriteByte(':')
-		if prices == nil {
-			buf.WriteString("null")
-			continue
-		}
-		innerFirst := true
-		buf.WriteByte('{')
-		for k, v := range prices {
-			if !innerFirst {
-				buf.WriteByte(',')
-			}
-			innerFirst = false
-			keyBytes, err := stdjson.Marshal(k)
-			if err != nil {
-				return nil, err
-			}
-			buf.Write(keyBytes)
-			buf.WriteByte(':')
-			buf.WriteString(strconv.FormatFloat(v, 'f', -1, 64))
-		}
-		buf.WriteByte('}')
-	}
-	buf.WriteByte('}')
-	return buf.Bytes(), nil
-}
 
 // ModelPrice represents a single model pricing entry in AIConf.ModelTable
 type ModelPrice struct {
@@ -254,13 +183,9 @@ type ModelPrice struct {
 	Capabilities        []string
 	SupportedParameters []string
 	Limits              map[string]interface{}
-	Prices              PriceMap     // default prices
+	Prices              PriceMap     // default prices (yuan per unit, float64)
 	TierPrices          TierPriceMap // tier name -> price table
 	Metadata            map[string]interface{}
-
-	// pricesInt and tierPricesInt are built at config load time.
-	pricesInt     map[string]int64
-	tierPricesInt map[string]map[string]int64
 }
 
 // ModelTable represents the cost/pricing table for a cluster
@@ -309,31 +234,7 @@ const (
 	PriceOutputCostPerImage          = "output_cost_per_image"
 	PriceInputCostPerImageToken      = "input_cost_per_image_token"
 	PriceOutputCostPerVideo          = "output_cost_per_video"
-
-	PriceInputCostPerTokenInt           = "input_cost_per_token_int"
-	PriceOutputCostPerTokenInt          = "output_cost_per_token_int"
-	PriceCacheReadInputTokenCostInt     = "cache_read_input_token_cost_int"
-	PriceCacheCreationInputTokenCostInt = "cache_creation_input_token_cost_int"
-	PriceInputCostPerAudioTokenInt      = "input_cost_per_audio_token_int"
-	PriceOutputCostPerAudioTokenInt     = "output_cost_per_audio_token_int"
-	PriceOutputCostPerImageInt          = "output_cost_per_image_int"
-	PriceInputCostPerImageTokenInt      = "input_cost_per_image_token_int"
-	PriceOutputCostPerVideoInt          = "output_cost_per_video_int"
 )
-
-// priceKeyToIntKey maps the public price keys (used in config files) to the
-// internal fixed-point integer keys used at runtime.
-var priceKeyToIntKey = map[string]string{
-	PriceInputCostPerToken:           PriceInputCostPerTokenInt,
-	PriceOutputCostPerToken:          PriceOutputCostPerTokenInt,
-	PriceCacheReadInputTokenCost:     PriceCacheReadInputTokenCostInt,
-	PriceCacheCreationInputTokenCost: PriceCacheCreationInputTokenCostInt,
-	PriceInputCostPerAudioToken:      PriceInputCostPerAudioTokenInt,
-	PriceOutputCostPerAudioToken:     PriceOutputCostPerAudioTokenInt,
-	PriceOutputCostPerImage:          PriceOutputCostPerImageInt,
-	PriceInputCostPerImageToken:      PriceInputCostPerImageTokenInt,
-	PriceOutputCostPerVideo:          PriceOutputCostPerVideoInt,
-}
 
 func (conf *BackendHTTPS) GetProtocol() string {
 	return conf.protocol
@@ -1409,34 +1310,15 @@ func ModelTableCheck(table *ModelTable) error {
 			return fmt.Errorf("negative price for model %s", price.Model)
 		}
 
-		price.pricesInt = make(map[string]int64)
-		price.pricesInt[PriceInputCostPerTokenInt] = quota.RmbToFixedPoint(input)
-		price.pricesInt[PriceOutputCostPerTokenInt] = quota.RmbToFixedPoint(output)
-		price.pricesInt[PriceCacheReadInputTokenCostInt] = quota.RmbToFixedPoint(cacheRead)
-		price.pricesInt[PriceCacheCreationInputTokenCostInt] = quota.RmbToFixedPoint(cacheWrite)
-		price.pricesInt[PriceInputCostPerAudioTokenInt] = quota.RmbToFixedPoint(audioInput)
-		price.pricesInt[PriceOutputCostPerAudioTokenInt] = quota.RmbToFixedPoint(audioOutput)
-		price.pricesInt[PriceOutputCostPerImageInt] = quota.RmbToFixedPoint(outputCostPerImage)
-		price.pricesInt[PriceInputCostPerImageTokenInt] = quota.RmbToFixedPoint(inputImageToken)
-		price.pricesInt[PriceOutputCostPerVideoInt] = quota.RmbToFixedPoint(outputCostPerVideo)
-
-		price.tierPricesInt = make(map[string]map[string]int64)
 		for tierName, tierPriceMap := range price.TierPrices {
 			if tierName != "peak" {
 				return fmt.Errorf("unsupported tier name %s in TierPrices for model %s, only 'peak' is allowed", tierName, price.Model)
 			}
-			intMap := make(map[string]int64)
 			for key, val := range tierPriceMap {
 				if val < 0 {
 					return fmt.Errorf("negative tier price %s for model %s tier %s", key, price.Model, tierName)
 				}
-				intKey := key
-				if mapped, ok := priceKeyToIntKey[key]; ok {
-					intKey = mapped
-				}
-				intMap[intKey] = quota.RmbToFixedPoint(val)
 			}
-			price.tierPricesInt[tierName] = intMap
 		}
 
 		if table.priceIndex[price.Model] == nil {
@@ -1477,20 +1359,19 @@ func (table *ModelTable) ActiveTierName(now time.Time) string {
 	return ""
 }
 
-// GetPriceInt returns the fixed-point price for the given tier and key.
+// GetPrice returns the float64 price (yuan per unit) for the given tier and key.
 // If tier is empty or the tier/key is not configured, it falls back to default Prices.
-func (p *ModelPrice) GetPriceInt(tier, key string) int64 {
-	if tier != "" && p.tierPricesInt != nil {
-		if tierMap, ok := p.tierPricesInt[tier]; ok {
+// Prices stay float64 until a billing item is converted via quota.CalcCostUnits
+// at request time, so prices with more than 8 decimal places keep their precision.
+func (p *ModelPrice) GetPrice(tier, key string) float64 {
+	if tier != "" && p.TierPrices != nil {
+		if tierMap, ok := p.TierPrices[tier]; ok {
 			if v, ok := tierMap[key]; ok {
 				return v
 			}
 		}
 	}
-	if p.pricesInt != nil {
-		return p.pricesInt[key]
-	}
-	return 0
+	return p.Prices[key]
 }
 
 // LookupModelPrice looks up a model price entry by model and mode.

--- a/bfe_config/bfe_cluster_conf/cluster_conf/cluster_conf_load_test.go
+++ b/bfe_config/bfe_cluster_conf/cluster_conf/cluster_conf_load_test.go
@@ -144,11 +144,11 @@ func TestModelTableCheck(t *testing.T) {
 		if entry == nil {
 			t.Fatal("LookupModelPrice should return entry")
 		}
-		if entry.GetPriceInt("", PriceInputCostPerTokenInt) != 100 {
-			t.Errorf("input cost int = %v, want 100", entry.GetPriceInt("", PriceInputCostPerTokenInt))
+		if entry.GetPrice("", PriceInputCostPerToken) != 0.000001 {
+			t.Errorf("input cost = %v, want 0.000001", entry.GetPrice("", PriceInputCostPerToken))
 		}
-		if entry.GetPriceInt("", PriceOutputCostPerTokenInt) != 200 {
-			t.Errorf("output cost int = %v, want 200", entry.GetPriceInt("", PriceOutputCostPerTokenInt))
+		if entry.GetPrice("", PriceOutputCostPerToken) != 0.000002 {
+			t.Errorf("output cost = %v, want 0.000002", entry.GetPrice("", PriceOutputCostPerToken))
 		}
 	})
 
@@ -175,11 +175,11 @@ func TestModelTableCheck(t *testing.T) {
 		if entry == nil {
 			t.Fatal("LookupModelPrice should return entry")
 		}
-		if entry.GetPriceInt("", PriceCacheReadInputTokenCostInt) != 45 {
-			t.Errorf("cache read cost int = %v, want 45", entry.GetPriceInt("", PriceCacheReadInputTokenCostInt))
+		if entry.GetPrice("", PriceCacheReadInputTokenCost) != 0.0000004525 {
+			t.Errorf("cache read cost = %v, want 0.0000004525", entry.GetPrice("", PriceCacheReadInputTokenCost))
 		}
-		if entry.GetPriceInt("", PriceCacheCreationInputTokenCostInt) != 565 {
-			t.Errorf("cache write cost int = %v, want 565", entry.GetPriceInt("", PriceCacheCreationInputTokenCostInt))
+		if entry.GetPrice("", PriceCacheCreationInputTokenCost) != 0.00000565625 {
+			t.Errorf("cache write cost = %v, want 0.00000565625", entry.GetPrice("", PriceCacheCreationInputTokenCost))
 		}
 	})
 
@@ -206,11 +206,11 @@ func TestModelTableCheck(t *testing.T) {
 		if entry == nil {
 			t.Fatal("LookupModelPrice should return entry")
 		}
-		if entry.GetPriceInt("", PriceInputCostPerAudioTokenInt) != 2288 {
-			t.Errorf("audio input cost int = %v, want 2288", entry.GetPriceInt("", PriceInputCostPerAudioTokenInt))
+		if entry.GetPrice("", PriceInputCostPerAudioToken) != 0.00002288 {
+			t.Errorf("audio input cost = %v, want 0.00002288", entry.GetPrice("", PriceInputCostPerAudioToken))
 		}
-		if entry.GetPriceInt("", PriceOutputCostPerAudioTokenInt) != 4576 {
-			t.Errorf("audio output cost int = %v, want 4576", entry.GetPriceInt("", PriceOutputCostPerAudioTokenInt))
+		if entry.GetPrice("", PriceOutputCostPerAudioToken) != 0.00004576 {
+			t.Errorf("audio output cost = %v, want 0.00004576", entry.GetPrice("", PriceOutputCostPerAudioToken))
 		}
 	})
 
@@ -571,7 +571,7 @@ func TestActiveTierName(t *testing.T) {
 	}
 }
 
-func TestGetPriceInt(t *testing.T) {
+func TestGetPrice(t *testing.T) {
 	table := &ModelTable{
 		Currency: "RMB",
 		Models: []ModelPrice{
@@ -598,16 +598,57 @@ func TestGetPriceInt(t *testing.T) {
 		t.Fatal("LookupModelPrice should return entry")
 	}
 
-	if got := entry.GetPriceInt("", PriceInputCostPerTokenInt); got != 100000000 {
-		t.Errorf("default input cost = %d, want 100000000", got)
+	if got := entry.GetPrice("", PriceInputCostPerToken); got != 1 {
+		t.Errorf("default input cost = %v, want 1", got)
 	}
-	if got := entry.GetPriceInt("peak", PriceInputCostPerTokenInt); got != 1000000000 {
-		t.Errorf("peak input cost = %d, want 1000000000", got)
+	if got := entry.GetPrice("peak", PriceInputCostPerToken); got != 10 {
+		t.Errorf("peak input cost = %v, want 10", got)
 	}
-	if got := entry.GetPriceInt("peak", PriceOutputCostPerTokenInt); got != 200000000 {
-		t.Errorf("peak output cost (fallback) = %d, want 200000000", got)
+	if got := entry.GetPrice("peak", PriceOutputCostPerToken); got != 2 {
+		t.Errorf("peak output cost (fallback) = %v, want 2", got)
 	}
-	if got := entry.GetPriceInt("nonexistent", PriceInputCostPerTokenInt); got != 100000000 {
-		t.Errorf("nonexistent tier fallback = %d, want 100000000", got)
+	if got := entry.GetPrice("nonexistent", PriceInputCostPerToken); got != 1 {
+		t.Errorf("nonexistent tier fallback = %v, want 1", got)
+	}
+}
+
+func TestGetPriceHighPrecision(t *testing.T) {
+	// Prices with more than 8 decimal places must survive config loading
+	// without being truncated to fixed-point integers.
+	table := &ModelTable{
+		Currency: "RMB",
+		Models: []ModelPrice{
+			{
+				Model: "qwen2.5-omni-7b",
+				Mode:  "chat",
+				Prices: PriceMap{
+					PriceInputCostPerToken:  6.0168984e-09,
+					PriceOutputCostPerToken: 7.6234102728e-08,
+				},
+				TierPrices: TierPriceMap{
+					"peak": {
+						PriceOutputCostPerToken: 1.52468205456e-07,
+					},
+				},
+			},
+		},
+	}
+	if err := ModelTableCheck(table); err != nil {
+		t.Fatalf("ModelTableCheck failed: %v", err)
+	}
+	entry := LookupModelPrice(table, "qwen2.5-omni-7b", "chat")
+	if entry == nil {
+		t.Fatal("LookupModelPrice should return entry")
+	}
+
+	if got := entry.GetPrice("", PriceOutputCostPerToken); got != 7.6234102728e-08 {
+		t.Errorf("high precision output cost = %v, want 7.6234102728e-08", got)
+	}
+	if got := entry.GetPrice("peak", PriceOutputCostPerToken); got != 1.52468205456e-07 {
+		t.Errorf("high precision peak output cost = %v, want 1.52468205456e-07", got)
+	}
+	// input price is not configured in the peak tier: fall back to default.
+	if got := entry.GetPrice("peak", PriceInputCostPerToken); got != 6.0168984e-09 {
+		t.Errorf("peak input cost (fallback) = %v, want 6.0168984e-09", got)
 	}
 }

--- a/bfe_modules/mod_ai_token_auth/mod_ai_token_auth.go
+++ b/bfe_modules/mod_ai_token_auth/mod_ai_token_auth.go
@@ -571,13 +571,10 @@ func calcVideoGenerationCost(entry *cluster_conf.ModelPrice, usage *bfe_basic.To
 		videoCount = 0
 	}
 
-	costPerVideo := entry.GetPriceInt(tierName, cluster_conf.PriceOutputCostPerVideoInt)
-	if costPerVideo < 0 {
-		log.Logger.Warn("invalid model price for video generation model %s", entry.Model)
-		return 0
-	}
-
-	return videoCount * costPerVideo
+	// Prices stay float64 (yuan per unit); quota.CalcCostUnits converts each
+	// billing item to a fixed-point integer with rounding, so prices with
+	// more than 8 decimal places keep their precision.
+	return quota.CalcCostUnits(videoCount, entry.GetPrice(tierName, cluster_conf.PriceOutputCostPerVideo))
 }
 
 func calcImageGenerationCost(entry *cluster_conf.ModelPrice, usage *bfe_basic.TokenUsage, tierName string) int64 {
@@ -586,24 +583,12 @@ func calcImageGenerationCost(entry *cluster_conf.ModelPrice, usage *bfe_basic.To
 		imageCount = 0
 	}
 
-	costPerImage := entry.GetPriceInt(tierName, cluster_conf.PriceOutputCostPerImageInt)
-	inputImageTokenCost := entry.GetPriceInt(tierName, cluster_conf.PriceInputCostPerImageTokenInt)
-	if costPerImage < 0 || inputImageTokenCost < 0 {
-		log.Logger.Warn("invalid model price for image generation model %s", entry.Model)
-		return 0
-	}
-
-	return imageCount*costPerImage + usage.ImageInputTokens*inputImageTokenCost
+	cost := quota.CalcCostUnits(imageCount, entry.GetPrice(tierName, cluster_conf.PriceOutputCostPerImage))
+	cost += quota.CalcCostUnits(usage.ImageInputTokens, entry.GetPrice(tierName, cluster_conf.PriceInputCostPerImageToken))
+	return cost
 }
 
 func calcChatCost(entry *cluster_conf.ModelPrice, usage *bfe_basic.TokenUsage, tierName string) int64 {
-	inputCost := entry.GetPriceInt(tierName, cluster_conf.PriceInputCostPerTokenInt)
-	outputCost := entry.GetPriceInt(tierName, cluster_conf.PriceOutputCostPerTokenInt)
-	if inputCost < 0 || outputCost < 0 {
-		log.Logger.Warn("invalid model price for model %s", entry.Model)
-		return 0
-	}
-
 	promptTokens := usage.PromptTokens
 	completionTokens := usage.CompletionTokens
 	cacheReadTokens := usage.CacheReadTokens
@@ -634,11 +619,11 @@ func calcChatCost(entry *cluster_conf.ModelPrice, usage *bfe_basic.TokenUsage, t
 		audioOutputTokens = completionTokens
 	}
 
-	cacheReadCost := entry.GetPriceInt(tierName, cluster_conf.PriceCacheReadInputTokenCostInt)
-	cacheWriteCost := entry.GetPriceInt(tierName, cluster_conf.PriceCacheCreationInputTokenCostInt)
-	audioInputCost := entry.GetPriceInt(tierName, cluster_conf.PriceInputCostPerAudioTokenInt)
-	audioOutputCost := entry.GetPriceInt(tierName, cluster_conf.PriceOutputCostPerAudioTokenInt)
-	imageInputCost := entry.GetPriceInt(tierName, cluster_conf.PriceInputCostPerImageTokenInt)
+	cacheReadPrice := entry.GetPrice(tierName, cluster_conf.PriceCacheReadInputTokenCost)
+	cacheWritePrice := entry.GetPrice(tierName, cluster_conf.PriceCacheCreationInputTokenCost)
+	audioInputPrice := entry.GetPrice(tierName, cluster_conf.PriceInputCostPerAudioToken)
+	audioOutputPrice := entry.GetPrice(tierName, cluster_conf.PriceOutputCostPerAudioToken)
+	imageInputPrice := entry.GetPrice(tierName, cluster_conf.PriceInputCostPerImageToken)
 
 	// normal input/output start as the full totals
 	normalInput := promptTokens
@@ -648,7 +633,7 @@ func calcChatCost(entry *cluster_conf.ModelPrice, usage *bfe_basic.TokenUsage, t
 	// PromptTokens is the total input (for Anthropic it is normalized to
 	// input_tokens + cache read + cache write at parse time), so both cache
 	// parts must be removed to get the normal (fresh) input tokens.
-	if cacheReadCost > 0 || cacheWriteCost > 0 {
+	if cacheReadPrice > 0 || cacheWritePrice > 0 {
 		normalInput = promptTokens - cacheReadTokens - cacheWriteTokens
 		if normalInput < 0 {
 			normalInput = 0
@@ -657,7 +642,7 @@ func calcChatCost(entry *cluster_conf.ModelPrice, usage *bfe_basic.TokenUsage, t
 
 	// image-aware billing: split image input from normal input
 	imageInputTokens := usage.ImageInputTokens
-	if imageInputCost > 0 {
+	if imageInputPrice > 0 {
 		if imageInputTokens > normalInput {
 			imageInputTokens = normalInput
 		}
@@ -671,7 +656,7 @@ func calcChatCost(entry *cluster_conf.ModelPrice, usage *bfe_basic.TokenUsage, t
 	}
 
 	// audio-aware billing: split audio input from normal input
-	if audioInputCost > 0 {
+	if audioInputPrice > 0 {
 		if audioInputTokens > normalInput {
 			audioInputTokens = normalInput
 		}
@@ -685,7 +670,7 @@ func calcChatCost(entry *cluster_conf.ModelPrice, usage *bfe_basic.TokenUsage, t
 	}
 
 	// audio-aware billing: split audio output from completion
-	if audioOutputCost > 0 {
+	if audioOutputPrice > 0 {
 		if audioOutputTokens > completionTokens {
 			audioOutputTokens = completionTokens
 		}
@@ -698,19 +683,18 @@ func calcChatCost(entry *cluster_conf.ModelPrice, usage *bfe_basic.TokenUsage, t
 		audioOutputTokens = 0
 	}
 
-	var cost int64
-	if cacheReadCost > 0 || cacheWriteCost > 0 || audioInputCost > 0 || audioOutputCost > 0 || imageInputCost > 0 {
-		cost = normalInput*inputCost +
-			cacheReadTokens*cacheReadCost +
-			cacheWriteTokens*cacheWriteCost +
-			audioInputTokens*audioInputCost +
-			imageInputTokens*imageInputCost +
-			normalOutput*outputCost +
-			audioOutputTokens*audioOutputCost
-	} else {
-		// fallback to legacy billing when no cache/audio/image price is configured
-		cost = promptTokens*inputCost + completionTokens*outputCost
-	}
+	// Each billing item is converted to a fixed-point integer separately and
+	// the integers are summed, so floating point only participates in single
+	// multiplications well below 2^53. Items with an unconfigured price (0)
+	// contribute nothing, which preserves the legacy fallback semantics of
+	// billing unconfigured sub-token usage at the normal input/output price.
+	cost := quota.CalcCostUnits(normalInput, entry.GetPrice(tierName, cluster_conf.PriceInputCostPerToken))
+	cost += quota.CalcCostUnits(cacheReadTokens, cacheReadPrice)
+	cost += quota.CalcCostUnits(cacheWriteTokens, cacheWritePrice)
+	cost += quota.CalcCostUnits(audioInputTokens, audioInputPrice)
+	cost += quota.CalcCostUnits(imageInputTokens, imageInputPrice)
+	cost += quota.CalcCostUnits(normalOutput, entry.GetPrice(tierName, cluster_conf.PriceOutputCostPerToken))
+	cost += quota.CalcCostUnits(audioOutputTokens, audioOutputPrice)
 
 	return cost
 }

--- a/bfe_modules/mod_ai_token_auth/mod_ai_token_auth_test.go
+++ b/bfe_modules/mod_ai_token_auth/mod_ai_token_auth_test.go
@@ -2060,3 +2060,106 @@ func TestTokenRequestFinishHandler_EstimateRequiresCompletedResponse(t *testing.
 		t.Errorf("expected remaining %d, got %d", rmbPlan.Quota-expectedCost, remaining)
 	}
 }
+
+func TestCalcChatCost_HighPrecision(t *testing.T) {
+	// Prices with more than 8 decimal places (from the generated model
+	// catalog) must not be truncated at config load time. The old
+	// fixed-point conversion mapped 7.6234102728e-08 to 7 (1e-8 yuan),
+	// undercharging by ~8%; the float64 + per-item rounding path keeps
+	// the full precision until the final rounding step.
+	entry := &cluster_conf.ModelPrice{
+		Model: "qwen2.5-omni-7b",
+		Mode:  "chat",
+		Prices: cluster_conf.PriceMap{
+			cluster_conf.PriceInputCostPerToken:  6.0168984e-09,
+			cluster_conf.PriceOutputCostPerToken: 7.6234102728e-08,
+		},
+	}
+
+	usage := &bfe_basic.TokenUsage{
+		PromptTokens:     1000000,
+		CompletionTokens: 1000000,
+	}
+
+	// input:  round(1e6 * 6.0168984e-09 * 1e8) = round(601689.84)    = 601690
+	// output: round(1e6 * 7.6234102728e-08 * 1e8) = round(7623410.2728) = 7623410
+	expectedCost := int64(601690 + 7623410)
+	if got := calcChatCost(entry, usage, ""); got != expectedCost {
+		t.Errorf("high precision cost = %d, want %d", got, expectedCost)
+	}
+}
+
+func TestCalcChatCost_HighPrecisionTier(t *testing.T) {
+	entry := &cluster_conf.ModelPrice{
+		Model: "glm-4.6",
+		Mode:  "chat",
+		Prices: cluster_conf.PriceMap{
+			cluster_conf.PriceInputCostPerToken:  3.0084492e-06,
+			cluster_conf.PriceOutputCostPerToken: 1.4049457764e-05,
+		},
+		TierPrices: cluster_conf.TierPriceMap{
+			"peak": {
+				cluster_conf.PriceOutputCostPerToken: 2.8098915528e-05,
+			},
+		},
+	}
+
+	usage := &bfe_basic.TokenUsage{
+		PromptTokens:     10000,
+		CompletionTokens: 5000,
+	}
+
+	// peak: input falls back to default (round(10000*3.0084492e-06*1e8)=3008449),
+	// output uses tier price (round(5000*2.8098915528e-05*1e8)=14049458)
+	expectedCost := int64(3008449 + 14049458)
+	if got := calcChatCost(entry, usage, "peak"); got != expectedCost {
+		t.Errorf("peak high precision cost = %d, want %d", got, expectedCost)
+	}
+
+	// off-peak: round(5000*1.4049457764e-05*1e8)=7024729
+	expectedCost = int64(3008449 + 7024729)
+	if got := calcChatCost(entry, usage, ""); got != expectedCost {
+		t.Errorf("off-peak high precision cost = %d, want %d", got, expectedCost)
+	}
+}
+
+func TestCalcImageGenerationCost_HighPrecision(t *testing.T) {
+	entry := &cluster_conf.ModelPrice{
+		Model: "doubao-seedream-5-0",
+		Mode:  "image_generation",
+		Prices: cluster_conf.PriceMap{
+			cluster_conf.PriceOutputCostPerImage:     0.220619608,
+			cluster_conf.PriceInputCostPerImageToken: 1.7816e-06,
+		},
+	}
+
+	usage := &bfe_basic.TokenUsage{
+		ImageCount:       3,
+		ImageInputTokens: 2000,
+	}
+
+	// round(3*0.220619608*1e8) = 66185882
+	// round(2000*1.7816e-06*1e8) = 356320
+	expectedCost := int64(66185882 + 356320)
+	if got := calcImageGenerationCost(entry, usage, ""); got != expectedCost {
+		t.Errorf("image generation cost = %d, want %d", got, expectedCost)
+	}
+}
+
+func TestCalcVideoGenerationCost_HighPrecision(t *testing.T) {
+	entry := &cluster_conf.ModelPrice{
+		Model: "kling-video-pro",
+		Mode:  "video_generation",
+		Prices: cluster_conf.PriceMap{
+			cluster_conf.PriceOutputCostPerVideo: 0.20056328,
+		},
+	}
+
+	usage := &bfe_basic.TokenUsage{VideoCount: 2}
+
+	// round(2*0.20056328*1e8) = 40112656
+	expectedCost := int64(40112656)
+	if got := calcVideoGenerationCost(entry, usage, ""); got != expectedCost {
+		t.Errorf("video generation cost = %d, want %d", got, expectedCost)
+	}
+}

--- a/docs/zh_cn/modifications/2026-09-08-rmb-price-float-precision/design-changes.md
+++ b/docs/zh_cn/modifications/2026-09-08-rmb-price-float-precision/design-changes.md
@@ -1,0 +1,320 @@
+# BFE RMB 计费价格精度提升（浮点价格 + 结果取整）
+
+## 1. 背景
+
+控制面 `ai-gateway-api` 导入的模型目录（`model-list.yaml`，450 个模型）中，大量模型价格是 `unit_price_usd_per_1M × group_ratio / 1e6 × 6.8` 的计算结果，需要 **10~12 位小数** 才能无损表示，例如：
+
+| 模型 | 价格字段 | 值 |
+|------|---------|-----|
+| `qwen2.5-omni-7b` | `output_cost_per_token` | `7.6234102728e-08`（12 位小数） |
+| `Qwen/Qwen2.5-72B-Instruct` | `input_cost_per_token` | `4.141631732e-06`（11 位小数） |
+| `glm-4.6` | `output_cost_per_token` | `1.4049457764e-05`（11 位小数） |
+| `mimo-v2-flash` | `cache_read_input_token_cost` | `7.0197148e-08`（11 位小数） |
+
+当前 BFE 的做法是：配置加载阶段通过 `go-lib/quota.RmbToFixedPoint` 把浮点价格转换为 **1e-8 元定点整数**（`cluster_conf_load.go:1412-1449`），运行时 `calcChatCost` 等只做整数运算。对超精度价格这会引入系统性截断误差，以上述 `7.6234102728e-08` 为例：
+
+- 真实值 × 1e8 = `7.6234102728`（定点单位），截断为 int64 后为 `7`；
+- 相对误差约 **8.1%**，100 万 token 输出少收约 0.0062 元。
+
+同时 `ai-gateway-api` 的接口定义（`model-prices.md`）此前强制价格使用十进制表示法、禁止科学计数法，已不满足目录数据的表示需求。
+
+总体方案：
+
+1. 表示层放开科学计数法（ai-gateway-api 侧，另文描述）；
+2. **BFE 价格不再预转定点整数**：加载后保持 `float64`（元/token），运行时先乘 1e8 做浮点计算，每项计费结果四舍五入为定点整数后累加，用于 Redis 扣减。
+
+`go-lib` 侧已完成配套修改（commit `bfc855f`）：新增 `quota.CalcCostUnits(usage int64, priceYuan float64) int64`，`RmbToFixedPoint` 由截断改为四舍五入。本文描述 BFE 侧的修改。
+
+---
+
+## 2. 需求示例
+
+`cluster_conf.data` 中将出现科学计数法表示的价格（JSON 语法原生支持，`encoding/json` 可直接解析为 float64）：
+
+```json
+{
+    "AIConf": {
+        "Provider": "example-provider",
+        "ModelTable": {
+            "Currency": "RMB",
+            "Models": [
+                {
+                    "Provider": "example-provider",
+                    "Model": "qwen2.5-omni-7b",
+                    "BaseModel": "qwen2.5-omni-7b",
+                    "Mode": "chat",
+                    "Prices": {
+                        "input_cost_per_token": 6.0168984e-09,
+                        "output_cost_per_token": 7.6234102728e-08
+                    }
+                }
+            ]
+        }
+    }
+}
+```
+
+输出 100 万 token 的期望成本：
+
+```
+cost = round(1000000 × (7.6234102728e-08 × 1e8))
+     = round(7623410.2728)
+     = 7623410        （定点单位，即 0.07623410 元）
+```
+
+改造前同一请求只扣减 `7 × 1000000 = 7000000`（0.07 元），少收 8.1%。
+
+---
+
+## 3. 当前现状
+
+| 层级 | 当前实现 | 不足 |
+|------|---------|------|
+| 配置加载 | `cluster_conf_load.go:1412-1449`：对 9 个价格键逐个 `quota.RmbToFixedPoint` 预转定点整数，存入 `pricesInt` / `tierPricesInt`；`TierPrices` 同样转换（`:1423-1440`） | 超 8 位小数的价格在加载期即被截断，精度不可逆地丢失 |
+| 价格常量 | `cluster_conf_load.go:313-321` 定义 `Price*Int = "*_int"` 常量；`:325-336` `priceKeyToIntKey` 映射表 | 仅为定点转换服务 |
+| 价格取值 | `GetPriceInt(tier, key) int64`（`:1482-1494`）：tier 价优先、fallback 默认价 | 只能返回定点整数 |
+| 成本计算 | `mod_ai_token_auth.go`：`calcVideoGenerationCost`（`:574`）、`calcImageGenerationCost`（`:589-590`）、`calcChatCost`（`:600-641`）全部通过 `GetPriceInt` 取定点整数后做 int64 乘法 | 继承加载期的截断误差 |
+| Redis 扣减 | 单 Key 定点数 Lua（rmb_quota.md 8.1），`UsedCost` 为 1e-8 元 int64 | 无需改动 |
+
+---
+
+## 4. 变更目标
+
+1. `ModelTable` / `ModelPrice` 加载后价格保持 `float64`，删除 `pricesInt` / `tierPricesInt` 预转换及配套常量、映射表；
+2. `GetPriceInt(tier, key) int64` 改为 `GetPrice(tier, key) float64`，tier 命中 / fallback 语义不变；
+3. `calcChatCost` / `calcImageGenerationCost` / `calcVideoGenerationCost` / `calcResponsesCost` 改为**逐项** `quota.CalcCostUnits(用量, 浮点价格)` 取整后整数累加；
+4. `TokenUsage.UsedCost`、`QuotaPlan`、Redis Lua 扣减、tier 时段匹配、cache/audio/image 子项拆分与 clamp 逻辑**全部不变**；
+5. ≤8 位小数的存量价格，扣减金额与改造前**逐分一致**（由 go-lib 一致性测试保证）。
+
+---
+
+## 5. 变更总览
+
+```
+cluster_conf.data (浮点价格, 科学计数法或十进制)
+        │
+        ▼
+cluster_conf_load.go          改造前: RmbToFixedPoint 预转 int → pricesInt
+  ModelTableCheck /              改造后: 仅校验非负, 价格保持 float64
+  buildModelTableIndex
+        │
+        ▼
+mod_ai_token_auth.calcChatCost  改造前: int64 价格 × int64 token 数
+  / calcImageGenerationCost      改造后: 逐项 quota.CalcCostUnits(token数, 价格)
+  / calcVideoGenerationCost              = round(token数 × (价格 × 1e8)), int64 累加
+        │
+        ▼
+TokenUsage.UsedCost (int64, 1e-8 元) ──► Redis Lua DECRBY   （不变）
+```
+
+---
+
+## 6. 详细设计
+
+### 6.1 `bfe_config/bfe_cluster_conf/cluster_conf/cluster_conf_load.go`
+
+**删除**：
+
+- `ModelPrice` 的 `pricesInt map[string]int64` / `tierPricesInt map[string]map[string]int64` 字段（`:261-263`）；
+- `PriceInputCostPerTokenInt` 等 9 个 `*_int` 常量（`:313-321`）；
+- `priceKeyToIntKey` 映射表（`:325-336`）。
+
+**加载逻辑**（`:1387-1449` 循环内）：
+
+- 非负校验保留，对象从"定点转换结果"改为原始浮点值（现有 `input < 0 || ...` 检查逻辑不变）；
+- 删除 `pricesInt[...] = quota.RmbToFixedPoint(...)` 与 `tierPricesInt` 转换块；`TierPrices` 的 `peak` tier name 校验与 tier 价格非负校验保留；
+- `priceIndex` 构建不变。
+
+**取值方法**：
+
+```go
+// GetPrice returns the float64 price (yuan per unit) for the given tier and key.
+// If tier is empty or the tier/key is not configured, it falls back to default Prices.
+// Prices are kept as float64; conversion to fixed-point integers happens per
+// billing item at request time via quota.CalcCostUnits.
+func (p *ModelPrice) GetPrice(tier, key string) float64 {
+    if tier != "" && p.TierPrices != nil {
+        if tierMap, ok := p.TierPrices[tier]; ok {
+            if v, ok := tierMap[key]; ok {
+                return v
+            }
+        }
+    }
+    return p.Prices[key]
+}
+```
+
+说明：
+
+- tier 命中优先、`TierPrices[tier]` 未配置该键时 fallback 默认 `Prices` 的语义与 `GetPriceInt` 完全一致；
+- 未配置的键返回 0（map 零值），该计费项按 0 成本处理，与现状一致；
+- 加载期已拒绝负价格，运行时无需再做 `< 0` 守卫。
+
+### 6.2 `bfe_modules/mod_ai_token_auth/mod_ai_token_auth.go`
+
+**`calcChatCost`**：定点整数价格变量改为浮点价格，逐项换算后整数累加：
+
+```go
+func calcChatCost(entry *cluster_conf.ModelPrice, usage *bfe_basic.TokenUsage, tierName string) int64 {
+    // ... 原有 cache/audio/image 子项拆分与 clamp 逻辑完全不变,
+    // 得到 normalInput / cacheReadTokens / cacheWriteTokens /
+    //     audioInputTokens / imageInputTokens /
+    //     normalOutput / audioOutputTokens ...
+
+    // 逐项: round(用量 × (价格 × 1e8)), 整数累加避免浮点累加误差
+    cost := quota.CalcCostUnits(normalInput, entry.GetPrice(tierName, cluster_conf.PriceInputCostPerToken))
+    cost += quota.CalcCostUnits(cacheReadTokens, entry.GetPrice(tierName, cluster_conf.PriceCacheReadInputTokenCost))
+    cost += quota.CalcCostUnits(cacheWriteTokens, entry.GetPrice(tierName, cluster_conf.PriceCacheCreationInputTokenCost))
+    cost += quota.CalcCostUnits(audioInputTokens, entry.GetPrice(tierName, cluster_conf.PriceInputCostPerAudioToken))
+    cost += quota.CalcCostUnits(imageInputTokens, entry.GetPrice(tierName, cluster_conf.PriceInputCostPerImageToken))
+    cost += quota.CalcCostUnits(normalOutput, entry.GetPrice(tierName, cluster_conf.PriceOutputCostPerToken))
+    cost += quota.CalcCostUnits(audioOutputTokens, entry.GetPrice(tierName, cluster_conf.PriceOutputCostPerAudioToken))
+    return cost
+}
+```
+
+要点：
+
+- 原实现中"`cacheReadCost > 0 || ...` 才拆分、否则 fallback 全量按普通价计费"的分支判断**不再需要**——未配置子项价格时 `GetPrice` 返回 0，该项自然贡献 0 成本，等价于现状的回退语义（原有 `if` 分支可删除，行为不变）；
+- `calcResponsesCost` 复用 `calcChatCost`，无独立改动。
+
+**`calcImageGenerationCost` / `calcVideoGenerationCost`**：
+
+```go
+func calcImageGenerationCost(entry *cluster_conf.ModelPrice, usage *bfe_basic.TokenUsage, tierName string) int64 {
+    cost := quota.CalcCostUnits(usage.ImageCount, entry.GetPrice(tierName, cluster_conf.PriceOutputCostPerImage))
+    cost += quota.CalcCostUnits(usage.ImageInputTokens, entry.GetPrice(tierName, cluster_conf.PriceInputCostPerImageToken))
+    return cost
+}
+
+func calcVideoGenerationCost(entry *cluster_conf.ModelPrice, usage *bfe_basic.TokenUsage, tierName string) int64 {
+    return quota.CalcCostUnits(usage.VideoCount, entry.GetPrice(tierName, cluster_conf.PriceOutputCostPerVideo))
+}
+```
+
+`ImageCount` / `VideoCount` 的 `< 0` clamp 保留。
+
+### 6.3 依赖变更：`go-lib/quota`
+
+BFE `go.mod` 当前依赖 `github.com/bfenetworks/go-lib v0.0.2`（无 replace）。本次需要 `CalcCostUnits`，go-lib 已发布 `v0.0.4`（包含 `bfc855f`："quota: add CalcCostUnits and round RmbToFixedPoint"）：
+
+1. BFE `go.mod` 升级 `github.com/bfenetworks/go-lib v0.0.2 → v0.0.4`，`go mod tidy`。
+
+`RmbToFixedPoint` 改舍入对 BFE 的影响：仅作用于配额初始化/重置（`ToRedisValue` 路径），配额额度为元级数值，实际无行为差异。
+
+### 6.4 不变的部分
+
+| 项 | 说明 |
+|----|------|
+| `TokenUsage.UsedCost` / `UsedQuota` | 仍为 int64；`UsedCost` 单位 1e-8 元 |
+| `QuotaPlan` / `HasBalance` / `Deduct` | 语义不变 |
+| Redis Lua 扣减脚本 | 单 Key 定点数方案不变 |
+| `ActiveTierName` / `LookupModelPrice` | 时段匹配与 (model, mode) 索引不变 |
+| usage 解析（流式/非流式、DeepSeek/Responses 字段兜底） | 不变 |
+| 计费判定规则（issue #1352 系列） | 不变 |
+| conf-agent | 零改动，继续透传浮点价格 |
+
+---
+
+## 7. 计费公式速查
+
+chat 模式拆分公式（业务语义）与现状完全相同，仅"价格 → 定点整数"的换算时点从加载期推迟到每次计费项计算时：
+
+```
+cost = Σ round(分项用量_i × (分项价格_i × 1e8))
+```
+
+| 场景 | 改造前（加载期截断） | 改造后（运行时取整） |
+|------|--------------------|--------------------|
+| `output_cost_per_token = 7.6234102728e-08`，输出 100 万 token | 0.07 元（7,000,000 定点单位，-8.1%） | 0.076234 元（7,623,410 定点单位，误差 < 1e-8 元） |
+| `input_cost_per_token = 0.000002`，输入 1000 token | 0.0002 元（200,000 定点单位） | 完全一致 |
+| tier `peak` 命中且某键未配置 | fallback 默认价（定点整数） | fallback 默认价（浮点），逐项取整 |
+
+---
+
+## 8. 边界情况与兼容性
+
+1. **≤8 位小数价格逐分一致**：价格 ×1e8 恰为整数，`CalcCostUnits(usage, price) == usage × RmbToFixedPoint(price)`（go-lib `TestCalcCostUnitsConsistentWithFixedPoint` 保证）；存量 `cluster_conf.data` 无需迁移。
+2. **9 位小数价格略有差异**：模型目录中存在 `0.000155584` 这类 9 位小数价格（×1e8 = 15558.4 非整数），新方案按 15558400 定点单位/千 token 扣减，旧方案按 15558000，新方案更接近真实成本（差约 2.6e-6 元/千 token）。
+3. **float64 精度上限**：有效数字约 15~16 位，模型目录中的 12 位有效数字价格可无损表示；单次请求成本上界（0.01 元/token × 100 万 token ≈ 1e12 定点单位）远小于 2^53 ≈ 9e15，无溢出风险。
+4. **未配置价格键**：`GetPrice` 返回 0，该分项按 0 成本处理（未配置 `output_cost_per_video` 等时行为与现状一致）。
+5. **负价格**：仍在配置加载阶段拒绝（`ModelTableCheck` 报错），运行时不做守卫。
+6. **Redis 余额上限**：`MaxRMBQuota`（9000 万元）与 Lua 精度约束不受影响。
+
+---
+
+## 9. 测试计划
+
+### 9.1 单元测试
+
+- `cluster_conf_load_test.go`：
+  - `GetPriceInt` 相关用例（`:147-213`、`:574-610`）改为 `GetPrice`，断言值由定点整数改为浮点原值（如 `100` → `0.000001`）；
+  - 新增：科学计数法价格（`7.6234102728e-08`）加载后 `GetPrice` 返回原值；`TierPrices.peak` 命中 / fallback 语义回归。
+- `mod_ai_token_auth_test.go`：
+  - 现有 `TestCalcCostUnits_*` / `TestCalcChatCost_*` 系列**期望值无需修改**——它们经 `ModelTableCheck` 构建 entry 且价格均为 ≤8 位小数，一致性保证使期望值天然成立；
+  - 新增：12 位小数价格的 chat / image / video 计费用例，断言与手算 `round(用量 × 价格 × 1e8)` 一致（误差 0）；
+  - 新增：tier 价格超精度场景（`TierPrices.peak` 配 10 位小数）。
+- go-lib 侧测试已随 `bfc855f` 提交（`TestCalcCostUnits` / `TestCalcCostUnitsConsistentWithFixedPoint` / `TestRmbToFixedPointRounding`）。
+
+### 9.2 集成测试
+
+- 用 `model-list.yaml` 全量导入控制面 → InnerAPI 导出 → BFE 加载 → 发起 chat / image_generation 请求，核对 Redis 扣减金额与手算成本一致；
+- 流式（SSE）、cache 子项、视频按次、分时段（peak 命中/未命中）场景回归；
+- 存量 v0.4/v0.5 十进制 `cluster_conf.data` 回归：扣减金额与旧版本逐分一致。
+
+### 9.3 配置加载测试
+
+- `bfe -t test_conf` 校验含科学计数法价格的 `cluster_conf.data` 可正常加载（`encoding/json` 原生支持，无需改动解析代码）。
+
+---
+
+## 10. 实施步骤建议
+
+1. BFE `go.mod` 升级 go-lib 依赖至 `v0.0.4`（已发布，含 `bfc855f`），`go mod tidy`；
+2. 修改 `cluster_conf_load.go`（6.1），同步更新 `cluster_conf_load_test.go`；
+3. 修改 `mod_ai_token_auth.go`（6.2），新增超精度计费用例；
+4. `make test` 全量回归；
+5. 更新 `docs/zh_cn/sys_design/rmb_quota.md`：4.4 节（去掉定点预转换描述）、5 节（`go-lib/quota` 新增 `CalcCostUnits`）、7.6 节（`calcChatCost` 等改浮点）、11 节兼容性说明。
+
+---
+
+## 11. 影响范围
+
+| 文件 | 变更类型 |
+|------|---------|
+| `bfe_config/bfe_cluster_conf/cluster_conf/cluster_conf_load.go` | 删除定点预转换与 `*_int` 常量；`GetPriceInt` → `GetPrice` |
+| `bfe_modules/mod_ai_token_auth/mod_ai_token_auth.go` | `calcChatCost` / `calcImageGenerationCost` / `calcVideoGenerationCost` 改逐项 `quota.CalcCostUnits` |
+| `bfe_config/bfe_cluster_conf/cluster_conf/cluster_conf_load_test.go` | `GetPriceInt` 用例改造 |
+| `bfe_modules/mod_ai_token_auth/mod_ai_token_auth_test.go` | 新增超精度用例（现有期望值不变） |
+| `go.mod` / `go.sum` | go-lib `v0.0.2 → v0.0.4` |
+| `docs/zh_cn/sys_design/rmb_quota.md` | 文档同步 |
+
+无新增配置项；`cluster_conf.data` 格式不变（科学计数法本就是合法 JSON 数字字面量）。
+
+---
+
+## 12. 兼容性与风险
+
+### 12.1 兼容性
+
+- 存量 ≤8 位小数十进制配置：扣减金额逐分一致，无需迁移；
+- Redis 存量余额、Lua 脚本、`QuotaPlan` 语义：完全不变；
+- conf-agent、ai-gateway-api 导出链路：零改动（本变更仅消费方 BFE 调整）；
+- 9 位小数价格扣减略有上升（更准），幅度约 2.6e-6 元/千 token，可忽略。
+
+### 12.2 风险与缓解
+
+| 风险 | 缓解 |
+|------|------|
+| 浮点累加误差 | 逐项 `CalcCostUnits` 先取整为 int64 再累加，浮点只参与单項乘法（量级 < 2^53，精确） |
+| 未配置子项价格回退语义变化 | 删除的 `if cacheReadCost > 0 ...` 分支与"价格为 0 贡献 0 成本"数学等价，由现有 `TestCalcCostUnits_CacheFallback` / `AudioFallback` 用例回归保证 |
+| `GetPriceInt` 被外部引用 | 全库检索确认仅 `mod_ai_token_auth` 与两处 `_test.go` 使用，无跨模块影响 |
+| go-lib 版本漂移 | 使用已发布的正式版本 `v0.0.4` 并升级 `go.mod`，不使用 replace 本地路径 |
+
+---
+
+## 13. 参考资料
+
+- `docs/zh_cn/sys_design/rmb_quota.md`（RMB 配额设计，本次需同步更新）
+- go-lib commit `bfc855f`：`quota: add CalcCostUnits and round RmbToFixedPoint`
+- `ai-gateway-api/design-docs/api-define/OpenAPI接口定义/model-prices.md`（控制面接口定义，配套放开科学计数法）

--- a/docs/zh_cn/sys_design/rmb_quota.md
+++ b/docs/zh_cn/sys_design/rmb_quota.md
@@ -26,7 +26,7 @@ v0.6 引入 **图像生成按次计费**、**图片输入 token 计费**、**视
 
 ### 1.2 目标
 
-1. 配置层沿用 `AIConf.ModelTable`，价格以 `Prices` map（元/Token）下发，BFE 加载时转换为 1e-8 元/Token 定点整数；
+1. 配置层沿用 `AIConf.ModelTable`，价格以 `Prices` map（元/Token）下发并保持 `float64`（v0.6 起支持科学计数法与 8 位以上小数精度），仅在请求计费时逐项换算为 1e-8 元定点整数；
 2. `bfe_basic.TokenUsage` 增加 `UsedCost`，用于记录本次请求的 RMB 成本；
 3. `mod_ai_token_auth.QuotaPlan` 增加 `Unit`，`Deduct` / `HasBalance` 支持 RMB；
 4. 新增共享库 `go-lib/quota`，提供 RMB 定点数转换，供 ai-gateway-api 与 BFE 共同引用；
@@ -117,24 +117,22 @@ type AIConf struct {
 3. `Model` 为具体模型名；`Mode` 如 `"chat"`。
 4. 同一个 `Mode` 下，`Model` 不能重复。
 5. 加载时构建二维索引 `priceIndex[model][mode]`，便于运行时 O(1) 查询。
-6. 加载阶段通过 `go-lib/quota.RmbToFixedPoint` 将浮点价格转换为定点整数，BFE 内部和 Redis 中只使用整数。
+6. 加载阶段仅做价格非负校验并构建索引；价格保持 `float64`，不做定点整数预转换（见 4.4）。
 
 ### 4.4 配置加载阶段处理
 
-conf-agent 只负责配置下发，不做任何数据转换。`cluster_conf.data` 中 `AIConf.ModelTable.Models[].Prices` 仍按原始浮点数（元/Token）下发。
+conf-agent 只负责配置下发，不做任何数据转换。`cluster_conf.data` 中 `AIConf.ModelTable.Models[].Prices` 仍按原始浮点数（元/Token）下发，支持科学计数法表示（如 `7.6234102728e-08`）。
 
-当 `unit = "RMB"` 时，小数到整数的转换及索引构建必须在 BFE 内部完成，例如在 `ClusterConfCheck` 或 `AIConf` 专有校验阶段。转换逻辑统一放到共享库 `go-lib/quota`：
+为支持 8 位以上小数精度的价格（v0.6 模型目录中已有 10~12 位小数的价格），BFE 加载阶段**不再把价格预转换为定点整数**：价格以 `float64` 保存，仅在请求计费时通过 `go-lib/quota.CalcCostUnits` 逐项换算为定点整数（见 5、7.6）。加载阶段只完成非负校验与索引构建：
 
 ```go
-import "github.com/bfenetworks/go-lib/quota"
-
 func buildModelTableIndex(table *ModelTable) error {
     table.priceIndex = make(map[string]map[string]*ModelPrice)
 
     for i := range table.Models {
         price := &table.Models[i]
 
-        // 1. 价格转换：浮点元/Token -> 1e-8 元/Token 定点整数
+        // 1. 价格非负校验（价格保持 float64，不做定点转换）
         input := price.Prices["input_cost_per_token"]
         output := price.Prices["output_cost_per_token"]
         cacheRead := price.Prices["cache_read_input_token_cost"]
@@ -149,15 +147,7 @@ func buildModelTableIndex(table *ModelTable) error {
             inputCostPerImageToken < 0 || outputCostPerVideo < 0 {
             return fmt.Errorf("negative price for model %s", price.Model)
         }
-        price.Prices["input_cost_per_token_int"] = float64(quota.RmbToFixedPoint(input))
-        price.Prices["output_cost_per_token_int"] = float64(quota.RmbToFixedPoint(output))
-        price.Prices["cache_read_input_token_cost_int"] = float64(quota.RmbToFixedPoint(cacheRead))
-        price.Prices["cache_creation_input_token_cost_int"] = float64(quota.RmbToFixedPoint(cacheWrite))
-        price.Prices["input_cost_per_audio_token_int"] = float64(quota.RmbToFixedPoint(audioInput))
-        price.Prices["output_cost_per_audio_token_int"] = float64(quota.RmbToFixedPoint(audioOutput))
-        price.Prices["output_cost_per_image_int"] = float64(quota.RmbToFixedPoint(outputCostPerImage))
-        price.Prices["input_cost_per_image_token_int"] = float64(quota.RmbToFixedPoint(inputCostPerImageToken))
-        price.Prices["output_cost_per_video_int"] = float64(quota.RmbToFixedPoint(outputCostPerVideo))
+        // TierPrices 同样只做非负校验（tier name 初期只支持 "peak"）
 
         // 2. 构建 model -> mode 二维索引
         if table.priceIndex[price.Model] == nil {
@@ -170,7 +160,8 @@ func buildModelTableIndex(table *ModelTable) error {
 ```
 
 > 说明：
-> - 转换后 BFE 内部及 Redis Lua 中只使用整数，避免浮点误差。
+> - 定点换算推迟到请求计费时逐项完成（`quota.CalcCostUnits`，四舍五入），Redis Lua 中仍然只接触整数。
+> - 对 ≤8 位小数的价格，逐项换算结果与旧的"先转定点再相乘"行为逐分一致；超过 8 位小数的价格不再在加载期被截断。
 > - conf-agent 不感知 `unit` 类型，也不修改价格格式。
 > - `go-lib/quota` 同时被 ai-gateway-api 和 BFE 引用，保证管理面与数据面对 Redis 值的解释完全一致。
 
@@ -198,13 +189,9 @@ type ModelPrice struct {
     Capabilities        []string
     SupportedParameters []string
     Limits              map[string]interface{}
-    Prices              map[string]float64            // 默认价格
+    Prices              map[string]float64            // 默认价格（保持 float64，不预转定点整数）
     TierPrices          map[string]map[string]float64 // tier name -> 价格表
     Metadata            map[string]interface{}
-
-    // 运行时字段：配置加载阶段预计算定点整数
-    pricesInt     map[string]int64
-    tierPricesInt map[string]map[string]int64
 }
 
 type ModelTable struct {
@@ -235,7 +222,7 @@ type ModelTable struct {
 
 - 解析 `TimeZone` 并缓存 `*time.Location`。
 - 构建 `tierIndex[name] -> *PriceTier`，便于运行时 O(1) 查询。
-- 将 `TierPrices` 中每个 tier 的价格表同样通过 `go-lib/quota.RmbToFixedPoint` 转换为定点整数，存入 `tierPricesInt`。
+- `TierPrices` 不做定点转换，与 `Prices` 一样保持 `float64`，仅在请求计费时通过 `quota.CalcCostUnits` 逐项换算（见 7.6）。
 
 ## 5. 共享库 `go-lib/quota`
 
@@ -251,11 +238,19 @@ const (
 
 const RmbPrecision = 1e8
 
-// RmbToFixedPoint converts yuan to a fixed-point integer (1e-8 yuan per unit).
+// RmbToFixedPoint converts yuan to a fixed-point integer (1e-8 yuan per unit),
+// rounded (not truncated).
 func RmbToFixedPoint(yuan float64) int64
 
 // FixedPointToRmb converts a fixed-point integer back to yuan.
 func FixedPointToRmb(value int64) float64
+
+// CalcCostUnits computes the cost of a usage amount at the given price
+// (yuan per unit) and returns it as a fixed-point integer:
+// round(usage * (priceYuan * 1e8)). Prices may carry more than 8 decimal
+// places; each billing item is converted separately and the integers are
+// summed, so floating point only participates in single multiplications.
+func CalcCostUnits(usage int64, priceYuan float64) int64
 
 // ToRedisValue converts a quota value to a Redis fixed-point integer.
 func ToRedisValue(quota float64, unit string) int64
@@ -268,7 +263,7 @@ func FromRedisValue(value int64, unit string) float64
 
 - **`go-lib/quota`**：只负责 **单位与定点数之间的转换**，不依赖 Redis 客户端，不执行任何 Redis 命令。
 - **ai-gateway-api**：引用 `go-lib/quota`，负责管理面配额的初始化、重置、同步（使用 `IncrBy` 等）。
-- **BFE**：引用 `go-lib/quota`，负责数据面请求成本的计算与 Lua 原子扣减。
+- **BFE**：引用 `go-lib/quota`，负责数据面请求成本的计算与 Lua 原子扣减；模型价格保持 `float64`，仅在计费时通过 `CalcCostUnits` 逐项换算。
 
 ## 6. 基础数据结构改动
 
@@ -655,13 +650,7 @@ func calcVideoGenerationCost(entry *cluster_conf.ModelPrice, usage *bfe_basic.To
         videoCount = 0
     }
 
-    costPerVideo := entry.GetPriceInt(tierName, cluster_conf.PriceOutputCostPerVideoInt)
-    if costPerVideo < 0 {
-        log.Logger.Warn("invalid model price for video generation model %s", entry.Model)
-        return 0
-    }
-
-    return videoCount * costPerVideo
+    return quota.CalcCostUnits(videoCount, entry.GetPrice(tierName, cluster_conf.PriceOutputCostPerVideo))
 }
 
 func calcImageGenerationCost(entry *cluster_conf.ModelPrice, usage *bfe_basic.TokenUsage, tierName string) int64 {
@@ -670,24 +659,12 @@ func calcImageGenerationCost(entry *cluster_conf.ModelPrice, usage *bfe_basic.To
         imageCount = 0
     }
 
-    costPerImage := entry.GetPriceInt(tierName, cluster_conf.PriceOutputCostPerImageInt)
-    inputImageTokenCost := entry.GetPriceInt(tierName, cluster_conf.PriceInputCostPerImageTokenInt)
-    if costPerImage < 0 || inputImageTokenCost < 0 {
-        log.Logger.Warn("invalid model price for image generation model %s", entry.Model)
-        return 0
-    }
-
-    return imageCount*costPerImage + usage.ImageInputTokens*inputImageTokenCost
+    cost := quota.CalcCostUnits(imageCount, entry.GetPrice(tierName, cluster_conf.PriceOutputCostPerImage))
+    cost += quota.CalcCostUnits(usage.ImageInputTokens, entry.GetPrice(tierName, cluster_conf.PriceInputCostPerImageToken))
+    return cost
 }
 
 func calcChatCost(entry *cluster_conf.ModelPrice, usage *bfe_basic.TokenUsage, tierName string) int64 {
-    inputCost := entry.GetPriceInt(tierName, cluster_conf.PriceInputCostPerTokenInt)
-    outputCost := entry.GetPriceInt(tierName, cluster_conf.PriceOutputCostPerTokenInt)
-    if inputCost < 0 || outputCost < 0 {
-        log.Logger.Warn("invalid model price for model %s", entry.Model)
-        return 0
-    }
-
     promptTokens := usage.PromptTokens
     completionTokens := usage.CompletionTokens
     cacheReadTokens := usage.CacheReadTokens
@@ -718,11 +695,11 @@ func calcChatCost(entry *cluster_conf.ModelPrice, usage *bfe_basic.TokenUsage, t
         audioOutputTokens = completionTokens
     }
 
-    cacheReadCost := entry.GetPriceInt(tierName, cluster_conf.PriceCacheReadInputTokenCostInt)
-    cacheWriteCost := entry.GetPriceInt(tierName, cluster_conf.PriceCacheCreationInputTokenCostInt)
-    audioInputCost := entry.GetPriceInt(tierName, cluster_conf.PriceInputCostPerAudioTokenInt)
-    audioOutputCost := entry.GetPriceInt(tierName, cluster_conf.PriceOutputCostPerAudioTokenInt)
-    imageInputCost := entry.GetPriceInt(tierName, cluster_conf.PriceInputCostPerImageTokenInt)
+    cacheReadPrice := entry.GetPrice(tierName, cluster_conf.PriceCacheReadInputTokenCost)
+    cacheWritePrice := entry.GetPrice(tierName, cluster_conf.PriceCacheCreationInputTokenCost)
+    audioInputPrice := entry.GetPrice(tierName, cluster_conf.PriceInputCostPerAudioToken)
+    audioOutputPrice := entry.GetPrice(tierName, cluster_conf.PriceOutputCostPerAudioToken)
+    imageInputPrice := entry.GetPrice(tierName, cluster_conf.PriceInputCostPerImageToken)
 
     // normal input/output start as the full totals
     normalInput := promptTokens
@@ -732,7 +709,7 @@ func calcChatCost(entry *cluster_conf.ModelPrice, usage *bfe_basic.TokenUsage, t
     // PromptTokens is the total input (for Anthropic it is normalized to
     // input_tokens + cache read + cache write at parse time), so both cache
     // parts must be removed to get the normal (fresh) input tokens.
-    if cacheReadCost > 0 || cacheWriteCost > 0 {
+    if cacheReadPrice > 0 || cacheWritePrice > 0 {
         normalInput = promptTokens - cacheReadTokens - cacheWriteTokens
         if normalInput < 0 {
             normalInput = 0
@@ -741,7 +718,7 @@ func calcChatCost(entry *cluster_conf.ModelPrice, usage *bfe_basic.TokenUsage, t
 
     // image-aware billing: split image input from normal input
     imageInputTokens := usage.ImageInputTokens
-    if imageInputCost > 0 {
+    if imageInputPrice > 0 {
         if imageInputTokens > normalInput {
             imageInputTokens = normalInput
         }
@@ -755,7 +732,7 @@ func calcChatCost(entry *cluster_conf.ModelPrice, usage *bfe_basic.TokenUsage, t
     }
 
     // audio-aware billing: split audio input from normal input
-    if audioInputCost > 0 {
+    if audioInputPrice > 0 {
         if audioInputTokens > normalInput {
             audioInputTokens = normalInput
         }
@@ -769,7 +746,7 @@ func calcChatCost(entry *cluster_conf.ModelPrice, usage *bfe_basic.TokenUsage, t
     }
 
     // audio-aware billing: split audio output from completion
-    if audioOutputCost > 0 {
+    if audioOutputPrice > 0 {
         if audioOutputTokens > completionTokens {
             audioOutputTokens = completionTokens
         }
@@ -782,19 +759,15 @@ func calcChatCost(entry *cluster_conf.ModelPrice, usage *bfe_basic.TokenUsage, t
         audioOutputTokens = 0
     }
 
-    var cost int64
-    if cacheReadCost > 0 || cacheWriteCost > 0 || audioInputCost > 0 || audioOutputCost > 0 || imageInputCost > 0 {
-        cost = normalInput*inputCost +
-            cacheReadTokens*cacheReadCost +
-            cacheWriteTokens*cacheWriteCost +
-            audioInputTokens*audioInputCost +
-            imageInputTokens*imageInputCost +
-            normalOutput*outputCost +
-            audioOutputTokens*audioOutputCost
-    } else {
-        // fallback to legacy billing when no cache/audio/image price is configured
-        cost = promptTokens*inputCost + completionTokens*outputCost
-    }
+    // 逐项换算为定点整数后累加：未配置价格(0)的项自然贡献 0 成本，
+    // 等价于旧实现"未配置子项价格时回退到普通 input/output 价格"的语义。
+    cost := quota.CalcCostUnits(normalInput, entry.GetPrice(tierName, cluster_conf.PriceInputCostPerToken))
+    cost += quota.CalcCostUnits(cacheReadTokens, cacheReadPrice)
+    cost += quota.CalcCostUnits(cacheWriteTokens, cacheWritePrice)
+    cost += quota.CalcCostUnits(audioInputTokens, audioInputPrice)
+    cost += quota.CalcCostUnits(imageInputTokens, imageInputPrice)
+    cost += quota.CalcCostUnits(normalOutput, entry.GetPrice(tierName, cluster_conf.PriceOutputCostPerToken))
+    cost += quota.CalcCostUnits(audioOutputTokens, audioOutputPrice)
 
     return cost
 }
@@ -870,7 +843,7 @@ cost = prompt_tokens * input_cost_per_token
 - `req.Route.ClusterName` 在 `reverseproxy.go` 的 `aiClusterInvoke()` 中已被设置为最终实际使用的 cluster（包括 fallback 场景）。
 - `aiMeta.TargetModel` 在 `reverseproxy.go` 的 `doSingleAIForward()` 中已被设置为路由目标模型 + cluster `ModelMapping` 映射后的最终模型名。
 - 因此这里拿到的 `clusterName` 和 `targetModel` 就是计费所需的实际值。
-- 价格到定点整数的转换在配置加载阶段通过 `go-lib/quota` 完成，运行时 `calcCostUnits` 只处理整数，保证 Redis Lua 不接触浮点。
+- 价格保持 `float64` 直到计费：运行时 `calcChatCost` 等通过 `quota.CalcCostUnits` 把每个计费项换算为定点整数（四舍五入）后累加，`calcCostUnits` 只处理整数，保证 Redis Lua 不接触浮点。
 
 ### 7.7 定价匹配逻辑
 
@@ -919,22 +892,19 @@ func (table *ModelTable) ActiveTierName(now time.Time) string {
     return ""
 }
 
-func (p *ModelPrice) GetPriceInt(tier, key string) int64 {
-    if tier != "" && p.tierPricesInt != nil {
-        if tierMap, ok := p.tierPricesInt[tier]; ok {
+func (p *ModelPrice) GetPrice(tier, key string) float64 {
+    if tier != "" && p.TierPrices != nil {
+        if tierMap, ok := p.TierPrices[tier]; ok {
             if v, ok := tierMap[key]; ok {
                 return v
             }
         }
     }
-    if p.pricesInt != nil {
-        return p.pricesInt[key]
-    }
-    return 0
+    return p.Prices[key]
 }
 ```
 
-`calcCostUnits` 在计算成本前先调用 `ActiveTierName`，再按 tier 取价。以 `chat` 模式为例，`calcChatCost` 在读取 `inputCost`、`outputCost`、`cacheReadCost` 等定点整数价格时，均通过 `GetPriceInt(tierName, key)` 获取：命中 `peak` tier 且 `TierPrices.peak` 中配置了该键，则使用 tier 价格；否则 fallback 到默认 `Prices`。
+`calcCostUnits` 在计算成本前先调用 `ActiveTierName`，再按 tier 取价。以 `chat` 模式为例，`calcChatCost` 在读取 `inputCost`、`outputCost`、`cacheReadCost` 等浮点价格时，均通过 `GetPrice(tierName, key)` 获取：命中 `peak` tier 且 `TierPrices.peak` 中配置了该键，则使用 tier 价格；否则 fallback 到默认 `Prices`。
 
 ```go
 func (m *ModuleAITokenAuth) calcCostUnits(req *bfe_basic.Request, serverConf bfe_basic.ServerDataConfInterface, usage *bfe_basic.TokenUsage) int64 {
@@ -942,12 +912,12 @@ func (m *ModuleAITokenAuth) calcCostUnits(req *bfe_basic.Request, serverConf bfe
 
     tierName := cluster.AIConf.ModelTable.ActiveTierName(time.Now())
 
-    inputCost := entry.GetPriceInt(tierName, cluster_conf.PriceInputCostPerTokenInt)
-    outputCost := entry.GetPriceInt(tierName, cluster_conf.PriceOutputCostPerTokenInt)
-    cacheReadCost := entry.GetPriceInt(tierName, cluster_conf.PriceCacheReadInputTokenCostInt)
+    inputPrice := entry.GetPrice(tierName, cluster_conf.PriceInputCostPerToken)
+    outputPrice := entry.GetPrice(tierName, cluster_conf.PriceOutputCostPerToken)
+    cacheReadPrice := entry.GetPrice(tierName, cluster_conf.PriceCacheReadInputTokenCost)
     // ... 其他子项价格同样按 tierName 获取 ...
 
-    // 后续 cache/audio 拆分与 7.6 节一致
+    // 后续 cache/audio 拆分与逐项 quota.CalcCostUnits 换算同 7.6 节
 }
 ```
 
@@ -1144,7 +1114,7 @@ return {yuan, frac}
 }
 ```
 
-> 上例中 `input_cost_per_token = 0.000001` 元/Token，换算为固定点整数即 `100`（= 0.000001 * 1e8），表示 **0.1 元 / 百万 Token**；`cache_read_input_token_cost` 等子项价格同样通过 `quota.RmbToFixedPoint` 转换为定点整数；`output_cost_per_image = 0.03` 元/张，换算为定点整数 `3000000`；`input_cost_per_image_token = 0.0000005` 元/Token 换算为定点整数 `50`；`output_cost_per_video = 0.5` 元/个换算为定点整数 `50000000`。
+> 上例中 `input_cost_per_token = 0.000001` 元/Token，逐项计费时换算为固定点整数即 `100`（= round(1 * 0.000001 * 1e8)），表示 **0.1 元 / 百万 Token**；`cache_read_input_token_cost` 等子项价格在计费时同样通过 `quota.CalcCostUnits` 逐项换算为定点整数；`output_cost_per_image = 0.03` 元/张换算为 `3000000`；`input_cost_per_image_token = 0.0000005` 元/Token 换算为 `50`；`output_cost_per_video = 0.5` 元/个换算为 `50000000`。价格本身在加载与运行时均保持 `float64`。
 
 ### 9.2 分时段计费配置示例（DeepSeek）
 
@@ -1222,7 +1192,7 @@ return {yuan, frac}
      - 覆盖 `HandleRequestFinish` 多次触发时仅扣费一次（`deducted` 幂等标记）；
      - 覆盖客户端中断场景（issue #1352）：`ErrClientWrite` 且未拿到最终 usage 时零扣费（`EstimateToken` 开/关一致）、已拿到最终 usage 后中断按实际 usage 扣费、响应未完成时估算不生效（`TestTokenRequestFinishHandler_ClientAbort*` 系列）。
    - `ActiveTierName`：验证北京时区周一 10:00 命中 `peak`、周一 13:00 未命中、周六 10:00 未命中、周一 18:00 不命中（左闭右开）。
-   - `GetPriceInt`：验证命中 `peak` 时取 `TierPrices.peak`、未命中时 fallback 到 `Prices`、tier 中未配置某键时 fallback 到默认价格。
+   - `GetPrice`：验证命中 `peak` 时取 `TierPrices.peak`、未命中时 fallback 到 `Prices`、tier 中未配置某键时 fallback 到默认价格；验证超过 8 位小数的价格（如 `7.6234102728e-08`）加载后不被截断。
 
 2. **Lua 脚本测试**
    - 单 Key 定点数方案：验证扣减、余额归零、负数不溢出。
@@ -1247,7 +1217,7 @@ return {yuan, frac}
 ## 11. 兼容性与注意事项
 
 1. **存量 Token 配额完全兼容**：`Unit` 默认 `"total_token"`，走原有 Lua 扣减逻辑。
-2. **浮点禁止进入 Redis**：所有金额在 BFE 内部和 Redis 中均以固定点整数表示，避免浮点误差；价格浮点转换仅在 BFE 配置加载阶段完成，conf-agent 不做任何转换。
+2. **浮点禁止进入 Redis**：请求成本与余额在 BFE 内部和 Redis 中均以固定点整数表示；模型价格保持 `float64`，仅在计费时通过 `quota.CalcCostUnits` 逐项换算（四舍五入）为定点整数，conf-agent 不做任何转换。对 ≤8 位小数的价格，新方案与旧"加载期转定点"方案扣减金额逐分一致。
 3. **无 ModelTable 时的兜底行为**：若 RMB 配额计划命中的 cluster 没有配置 `ModelTable`，或没有匹配到模型条目，当前建议：
    - 记录告警日志；
    - 本次请求不对该 RMB 配额进行扣减（相当于按 `0` 成本处理）；

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/andybalholm/brotli v1.0.2
 	github.com/armon/go-radix v1.0.0
 	github.com/asergeyev/nradix v0.0.0-20170505151046-3872ab85bb56 // indirect
-	github.com/bfenetworks/go-lib v0.0.2
+	github.com/bfenetworks/go-lib v0.0.4
 	github.com/golang-jwt/jwt v3.2.2+incompatible
 	github.com/gomodule/redigo v2.0.0+incompatible
 	github.com/json-iterator/go v1.1.12

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,8 @@ github.com/bfenetworks/bfe-mock-waf v0.1.0 h1:dTd540S3nv6qNlG6lLC0F8qx3gyo5WB4wn
 github.com/bfenetworks/bfe-mock-waf v0.1.0/go.mod h1:MWZHbihiRQXpoUCvY1l18s2bfOBWx4N4pghxBt+xUv0=
 github.com/bfenetworks/bwi v0.1.2 h1:3AcCzUjyzKm+FeLgTIVg58u+SUdEVZdJbQM58Ezwjcg=
 github.com/bfenetworks/bwi v0.1.2/go.mod h1:zCRIdSw521zVnNCM73qw/lZ9UknbRux9rk6UQvBJgMA=
-github.com/bfenetworks/go-lib v0.0.2 h1:ZjWas7Icd3svzVdegSSM1kMYSrnZHRvoCx6SQ458pqg=
-github.com/bfenetworks/go-lib v0.0.2/go.mod h1:DNiKiff30CaX7uOUGJpP85VyTn+JSFoY9gfG2AxmPgM=
+github.com/bfenetworks/go-lib v0.0.4 h1:RcC+A4jUQoMvQS0ut5MLlgwp8lkJUlJq3Y3Qeop576E=
+github.com/bfenetworks/go-lib v0.0.4/go.mod h1:DNiKiff30CaX7uOUGJpP85VyTn+JSFoY9gfG2AxmPgM=
 github.com/bfenetworks/proxy-wasm-go-host v0.0.1 h1:FzgCnKC+fkeY4NtsUVBcYONOdhvsJA1FXei01VP17Qo=
 github.com/bfenetworks/proxy-wasm-go-host v0.0.1/go.mod h1:ooQK7XyIovzGQIADKbPdpfUJ3w+b2ou6iqDZLMq0pww=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=

--- a/tests/integration/implementation/scenario-SC03-rmb-quota/sc03_rmb_quota_test.go
+++ b/tests/integration/implementation/scenario-SC03-rmb-quota/sc03_rmb_quota_test.go
@@ -54,6 +54,7 @@ var cacheStreamBody = []byte(`{"model":"claude-opus-4-6","stream":true}`)
 var audioBody = []byte(`{"model":"gpt-audio-1.5"}`)
 var audioStreamBody = []byte(`{"model":"gpt-audio-1.5","stream":true}`)
 var imageGenerationBody = []byte(`{"model":"flux-2-pro","n":2}`)
+var highPrecisionBody = []byte(`{"model":"qwen2.5-omni-7b"}`)
 
 var usageResponse = `{"usage":{"prompt_tokens":100,"completion_tokens":50,"total_tokens":150}}`
 var imageGenerationUsageResponse = `{"usage":{"image_count":2}}`
@@ -305,6 +306,30 @@ func imageGenerationAIConf() *cluster_conf.AIConf {
 		},
 		Prices: cluster_conf.PriceMap{
 			"output_cost_per_image": 0.03,
+		},
+	})
+	return conf
+}
+
+// highPrecisionAIConf adds a model whose prices need more than 8 decimal
+// places. When marshaled to cluster_conf.data, encoding/json emits them in
+// scientific notation (e.g. 6.0168984e-09), which also exercises BFE's
+// config parsing of scientific-notation prices.
+func highPrecisionAIConf() *cluster_conf.AIConf {
+	conf := defaultRMBAIConf()
+	conf.ModelTable.Models = append(conf.ModelTable.Models, cluster_conf.ModelPrice{
+		Provider:            "mock-provider",
+		Model:               "qwen2.5-omni-7b",
+		BaseModel:           "qwen2.5-omni-7b",
+		Mode:                "chat",
+		Capabilities:        []string{"chat"},
+		SupportedParameters: []string{"temperature", "max_tokens"},
+		Limits: map[string]interface{}{
+			"context_window": 128000,
+		},
+		Prices: cluster_conf.PriceMap{
+			"input_cost_per_token":  6.0168984e-09,
+			"output_cost_per_token": 7.6234102728e-08,
 		},
 	})
 	return conf
@@ -825,5 +850,50 @@ func TestTC14_TokenQuotaZeroMissingRedisKey(t *testing.T) {
 	}
 	if e.backends[clusterRMB].Hits() != 0 {
 		t.Fatalf("expected no backend hit, got %d", e.backends[clusterRMB].Hits())
+	}
+}
+
+
+// TestTC15 verifies end-to-end billing with prices that need more than 8
+// decimal places (scientific notation in cluster_conf.data). The prices
+// below come from the generated model catalog. With prompt=100 and
+// completion=50 (usageResponse):
+//
+//	cost = round(100 * 6.0168984e-09 * 1e8) + round(50 * 7.6234102728e-08 * 1e8)
+//	     = round(60.168984) + round(381.17051364)
+//	     = 60 + 381 = 441 fixed-point units
+//
+// The pre-v0.6 load-time fixed-point conversion truncated the prices to
+// 0 and 7 (1e-8 yuan), which would have deducted only 350.
+func TestTC15_RMBQuotaDeduction_HighPrecision(t *testing.T) {
+	aiConfs := map[string]*cluster_conf.AIConf{
+		clusterRMB: highPrecisionAIConf(),
+	}
+	e := newTestEnv(t, aiConfs, []common.QuotaPlan{rmbQuotaPlan(10000000000)})
+	defer e.Close()
+
+	e.redis.SetQuota(redisKeyRMB, 10000000000)
+
+	resp, body, err := e.sendRequest(apiHost, highPrecisionBody)
+	if err != nil {
+		t.Fatalf("send request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		e.logBFEException()
+		t.Fatalf("expected status 200, got %d, body: %s", resp.StatusCode, body)
+	}
+
+	if e.backends[clusterRMB].Hits() != 1 {
+		t.Fatalf("expected 1 hit on %s, got %d", clusterRMB, e.backends[clusterRMB].Hits())
+	}
+
+	// wait for async redis deduction
+	time.Sleep(500 * time.Millisecond)
+	remaining := e.redis.GetQuota(redisKeyRMB)
+	want := int64(10000000000 - 441)
+	if remaining != want {
+		e.logBFEException()
+		e.logBFEAccess()
+		t.Fatalf("remaining quota = %d, want %d, response body: %s", remaining, want, body)
 	}
 }

--- a/tests/integration/implementation/scenario-SC09-rmb-tiered-pricing/sc09_rmb_tiered_pricing_test.go
+++ b/tests/integration/implementation/scenario-SC09-rmb-tiered-pricing/sc09_rmb_tiered_pricing_test.go
@@ -45,6 +45,7 @@ const (
 )
 
 var defaultBody = []byte(`{"model":"deepseek-chat"}`)
+var highPrecisionBody = []byte(`{"model":"glm-4.6"}`)
 var streamBody = []byte(`{"model":"deepseek-chat","stream":true}`)
 var cacheBody = []byte(`{"model":"deepseek-chat"}`)
 var cacheStreamBody = []byte(`{"model":"deepseek-chat","stream":true}`)
@@ -268,6 +269,36 @@ func noTierAIConf() *cluster_conf.AIConf {
 	return conf
 }
 
+// tierPeakHighPrecisionAIConf adds a model whose prices need more than 8
+// decimal places. The peak tier only overrides the output price, so the
+// input price exercises tier fallback to the default price. When marshaled
+// to cluster_conf.data the values are emitted in scientific notation
+// (e.g. 3.0084492e-06), which also exercises config parsing.
+func tierPeakHighPrecisionAIConf() *cluster_conf.AIConf {
+	conf := tierPeakAIConf()
+	conf.ModelTable.Models = append(conf.ModelTable.Models, cluster_conf.ModelPrice{
+		Provider:            "mock-provider",
+		Model:               "glm-4.6",
+		BaseModel:           "glm-4.6",
+		Mode:                "chat",
+		Capabilities:        []string{"chat"},
+		SupportedParameters: []string{"temperature", "max_tokens"},
+		Limits: map[string]interface{}{
+			"context_window": 128000,
+		},
+		Prices: cluster_conf.PriceMap{
+			"input_cost_per_token":  3.0084492e-06,
+			"output_cost_per_token": 1.4049457764e-05,
+		},
+		TierPrices: cluster_conf.TierPriceMap{
+			"peak": {
+				"output_cost_per_token": 2.8098915528e-05,
+			},
+		},
+	})
+	return conf
+}
+
 // TestTC01 verifies RMB quota deduction using peak tier prices for a non-streaming request.
 func TestTC01_RMBQuotaDeduction_Peak_NonStreaming(t *testing.T) {
 	aiConfs := map[string]*cluster_conf.AIConf{
@@ -484,6 +515,48 @@ func TestTC06_RMBQuotaDeduction_DeepSeekCacheDetailsField_Streaming(t *testing.T
 	// peak: input=200, cache_read=100, output=400
 	// cost = 3000*200 + 5000*100 + 1500*400 = 1,700,000
 	want := int64(10000000000 - 1700000)
+	if remaining != want {
+		e.logBFEException()
+		e.logBFEAccess()
+		t.Fatalf("remaining quota = %d, want %d, response body: %s", remaining, want, body)
+	}
+}
+
+
+// TestTC07 verifies peak tier billing with prices that need more than 8
+// decimal places (scientific notation in cluster_conf.data). The peak tier
+// only overrides the output price; the input price falls back to the
+// default price. With prompt=100 and completion=50 (usageResponse):
+//
+//	input:  round(100 * 3.0084492e-06 * 1e8) = round(30084.492)    = 30084
+//	output: round(50 * 2.8098915528e-05 * 1e8) = round(140494.57764) = 140495
+//	total = 170579 fixed-point units
+func TestTC07_RMBQuotaDeduction_Peak_HighPrecision(t *testing.T) {
+	aiConfs := map[string]*cluster_conf.AIConf{
+		clusterTierPeak: tierPeakHighPrecisionAIConf(),
+	}
+	e := newTestEnv(t, aiConfs)
+	defer e.Close()
+
+	e.redis.SetQuota(redisKeyRMB, 10000000000)
+
+	resp, body, err := e.sendRequest(apiHost, highPrecisionBody)
+	if err != nil {
+		t.Fatalf("send request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		e.logBFEException()
+		t.Fatalf("expected status 200, got %d, body: %s", resp.StatusCode, body)
+	}
+
+	if e.backends[clusterTierPeak].Hits() != 1 {
+		t.Fatalf("expected 1 hit on %s, got %d", clusterTierPeak, e.backends[clusterTierPeak].Hits())
+	}
+
+	// wait for async redis deduction
+	time.Sleep(500 * time.Millisecond)
+	remaining := e.redis.GetQuota(redisKeyRMB)
+	want := int64(10000000000 - 170579)
 	if remaining != want {
 		e.logBFEException()
 		e.logBFEAccess()


### PR DESCRIPTION


Model catalog prices may need 10-12 decimal places (e.g. 7.6234102728e-08 yuan/token). The previous load-time fixed-point conversion truncated such prices to 1e-8 yuan integers, undercharging by ~8% per token.

- cluster_conf: drop pricesInt/tierPricesInt pre-conversion, the *_int key constants and the priceKeyToIntKey map; replace GetPriceInt(tier, key) int64 with GetPrice(tier, key) float64. Prices (including TierPrices) stay float64 and load-time validation now only checks non-negativity.
- cluster_conf: remove the custom PriceMap/TierPriceMap MarshalJSON that forced decimal notation; scientific notation (e.g. 1.5e-6) is now accepted in cluster_conf.data.
- mod_ai_token_auth: calcChatCost/calcImageGenerationCost/ calcVideoGenerationCost convert each billing item via the new quota.CalcCostUnits (round(usage * (price * 1e8))) and sum integers, so sub-item split/fallback semantics are unchanged and Redis Lua still only sees integers.
- go.mod: bump github.com/bfenetworks/go-lib to v0.0.4 (adds quota.CalcCostUnits, rounds RmbToFixedPoint).
- tests: update GetPriceInt cases to GetPrice; add high-precision unit tests; add SC03 TestTC15 and SC09 TestTC07 integration tests covering scientific-notation prices end to end, including tier fallback.
- docs: update rmb_quota.md and add modifications design doc.

For prices with at most 8 decimal places the deduction amounts are identical to the previous convert-at-load behavior.