### PR TITLE
fix(mod_ai_token_auth): bill complete usage for cross-protocol non-streaming responses

### DIFF
--- a/bfe_balance/bal_gslb/bal_gslb.go
+++ b/bfe_balance/bal_gslb/bal_gslb.go
@@ -361,9 +361,32 @@ func (bal *BalanceGslb) callEPP(conn *grpc.ClientConn, metadata *corev3.Metadata
 		return "", nil, err
 	}
 
+	headers := epp.BuildEnvoyGRPCHeaders(req.OutRequest.Header, true, !hasBody)
+	// llm-d EPP routes request parsers by the :path pseudo-header; without it
+	// the request falls back to the legacy /v1/completions default and body
+	// parsing fails for chat-completions payloads.
+	var path, method string
+	if req.OutRequest.URL != nil {
+		path = req.OutRequest.URL.RequestURI()
+		if path == "" {
+			path = req.OutRequest.URL.Path
+		}
+		method = req.OutRequest.Method
+	}
+	if path == "" {
+		path = "/"
+	}
+	if method == "" {
+		method = "POST"
+	}
+	headers.Headers.Headers = append([]*corev3.HeaderValue{
+		{Key: ":path", RawValue: []byte(path)},
+		{Key: ":method", RawValue: []byte(method)},
+	}, headers.Headers.Headers...)
+
 	reqMsg := &extprocv3.ProcessingRequest{
 		Request: &extprocv3.ProcessingRequest_RequestHeaders{
-			RequestHeaders: epp.BuildEnvoyGRPCHeaders(req.OutRequest.Header, true, !hasBody),
+			RequestHeaders: headers,
 		},
 		MetadataContext: metadata,
 	}

--- a/bfe_model_protocol/utils/usage_parse.go
+++ b/bfe_model_protocol/utils/usage_parse.go
@@ -78,6 +78,33 @@ func ParseOpenAIUsageFields(data []byte) UsageFields {
 	return fields
 }
 
+// ParseUsageFieldsCrossProtocol extracts usage fields by composing the
+// protocol chains: the OpenAI-family chain first, then the Anthropic
+// (Claude) chain when no OpenAI-style prompt/completion tokens are
+// present. This mirrors the legacy all-chain extraction field-for-field
+// and is response-format-agnostic: it recovers the full usage even when
+// the auth style detected from the request does not match the format of
+// the response body (issue #1364, e.g. a Bearer key detected as openai
+// while the backend returns an Anthropic body).
+func ParseUsageFieldsCrossProtocol(data []byte) UsageFields {
+	fields := ParseOpenAIUsageFields(data)
+	if fields.PromptTokens == 0 && fields.CompletionTokens == 0 {
+		claude := ParseAnthropicUsageFields(data)
+		fields.PromptTokens = claude.PromptTokens
+		fields.CompletionTokens = claude.CompletionTokens
+		if fields.CacheReadTokens == 0 {
+			fields.CacheReadTokens = claude.CacheReadTokens
+		}
+		if fields.CacheWriteTokens == 0 {
+			fields.CacheWriteTokens = claude.CacheWriteTokens
+		}
+		if fields.UsedQuota == 0 {
+			fields.UsedQuota = claude.UsedQuota
+		}
+	}
+	return fields
+}
+
 // ParseAnthropicUsageFields extracts usage fields from Anthropic (Claude)
 // response bodies: input_tokens / output_tokens /
 // cache_read_input_tokens / cache_creation_input_tokens.

--- a/bfe_model_protocol/utils/usage_parse_test.go
+++ b/bfe_model_protocol/utils/usage_parse_test.go
@@ -1,0 +1,67 @@
+// Copyright (c) 2026 The BFE Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import "testing"
+
+func TestParseUsageFieldsCrossProtocol_AnthropicBody(t *testing.T) {
+	// OpenAI chain parses nothing from an Anthropic body; the anthropic
+	// chain must recover the full usage (issue #1364).
+	fields := ParseUsageFieldsCrossProtocol([]byte(
+		`{"id":"msg_01","type":"message","role":"assistant","usage":{"input_tokens":320,"output_tokens":150,"cache_read_input_tokens":8000,"cache_creation_input_tokens":200}}`))
+	if fields.PromptTokens != 8520 {
+		t.Errorf("expected PromptTokens 8520 (320+8000+200), got %d", fields.PromptTokens)
+	}
+	if fields.CompletionTokens != 150 {
+		t.Errorf("expected CompletionTokens 150, got %d", fields.CompletionTokens)
+	}
+	if fields.CacheReadTokens != 8000 || fields.CacheWriteTokens != 200 {
+		t.Errorf("unexpected cache tokens: %+v", fields)
+	}
+	if fields.UsedQuota != 8670 {
+		t.Errorf("expected UsedQuota 8670 (8520+150), got %d", fields.UsedQuota)
+	}
+}
+
+func TestParseUsageFieldsCrossProtocol_OpenAIBodyUnchanged(t *testing.T) {
+	// OpenAI-style bodies keep the openai chain result; the anthropic
+	// fallback must not kick in.
+	fields := ParseUsageFieldsCrossProtocol([]byte(
+		`{"usage":{"total_tokens":12,"prompt_tokens":8,"completion_tokens":4,"cache_read_tokens":5}}`))
+	if fields.PromptTokens != 8 || fields.CompletionTokens != 4 || fields.UsedQuota != 12 {
+		t.Errorf("unexpected openai fields: %+v", fields)
+	}
+	if fields.CacheReadTokens != 5 {
+		t.Errorf("expected CacheReadTokens 5, got %d", fields.CacheReadTokens)
+	}
+}
+
+func TestParseUsageFieldsCrossProtocol_FullCacheHit(t *testing.T) {
+	fields := ParseUsageFieldsCrossProtocol([]byte(
+		`{"type":"message","usage":{"input_tokens":0,"output_tokens":42,"cache_read_input_tokens":5000}}`))
+	if fields.PromptTokens != 5000 || fields.CacheReadTokens != 5000 {
+		t.Errorf("unexpected full-cache-hit fields: %+v", fields)
+	}
+	if fields.UsedQuota != 5042 {
+		t.Errorf("expected UsedQuota 5042 (5000+42), got %d", fields.UsedQuota)
+	}
+}
+
+func TestParseUsageFieldsCrossProtocol_NoUsage(t *testing.T) {
+	fields := ParseUsageFieldsCrossProtocol([]byte(`{"id":"chatcmpl-1","choices":[{"delta":{"content":"hi"}}]}`))
+	if fields.PromptTokens != 0 || fields.CompletionTokens != 0 || fields.UsedQuota != 0 {
+		t.Errorf("expected all-zero fields for usage-less body, got %+v", fields)
+	}
+}

--- a/bfe_modules/mod_ai_token_auth/mod_ai_token_auth.go
+++ b/bfe_modules/mod_ai_token_auth/mod_ai_token_auth.go
@@ -30,6 +30,7 @@ import (
 	"github.com/bfenetworks/bfe/bfe_config/bfe_cluster_conf/cluster_conf"
 	"github.com/bfenetworks/bfe/bfe_http"
 	modelprotocol "github.com/bfenetworks/bfe/bfe_model_protocol"
+	"github.com/bfenetworks/bfe/bfe_model_protocol/utils"
 	"github.com/bfenetworks/bfe/bfe_module"
 	"github.com/bfenetworks/bfe/bfe_util/redis_client"
 )
@@ -119,6 +120,16 @@ func UpdateCtxByUsage(ctx *TokenAuthContext, data []byte) {
 	// aiMeta.AuthStyle carries the same usage chain the legacy all-chain
 	// extraction applied to this response.
 	fields := modelprotocol.Get(ctx.aiBasicInfo.AuthStyle).ExtractUsageFields(data)
+	if fields.UsedQuota == 0 && fields.PromptTokens == 0 && fields.CompletionTokens == 0 &&
+		fields.ImageCount == 0 && fields.VideoCount == 0 {
+		// Auth style / response format mismatch (e.g. a Bearer key detected
+		// as openai while the backend returns an Anthropic body): the
+		// single adapter parsed nothing. Fall back to the composed
+		// cross-protocol chain so the final usage is still recognized
+		// (issue #1364); otherwise UsedQuota stays 0, the final-usage mark
+		// is never set, and the request-finish guard would zero the usage.
+		fields = utils.ParseUsageFieldsCrossProtocol(data)
+	}
 	used := fields.UsedQuota
 	prompt := fields.PromptTokens
 	completion := fields.CompletionTokens
@@ -238,11 +249,21 @@ func (m *ModuleAITokenAuth) tokenRequestFinishHandler(req *bfe_basic.Request, re
 	// size, completion tokens accumulated from response content) are only
 	// billable when the response completed normally. Reset them otherwise:
 	// calcCostUnits below bills from the token fields directly, so guarding
-	// UsedQuota alone is not enough.
+	// UsedQuota alone is not enough. All billing fields must be cleared:
+	// leaving sub-token fields (cache/audio/image) behind would let
+	// calcCostUnits bill the survivors alone (issue #1364: an unrecognized
+	// final usage was reduced to CacheReadTokens and billed cache-read only).
 	estimateBillable := ctx.aiBasicInfo.IsAllowEstimateToken() && ctx.aiBasicInfo.IsResponseCompleted()
 	if !ctx.aiBasicInfo.IsFinalUsageSeen() && !estimateBillable {
 		tokenUsage.PromptTokens = 0
 		tokenUsage.CompletionTokens = 0
+		tokenUsage.CacheReadTokens = 0
+		tokenUsage.CacheWriteTokens = 0
+		tokenUsage.AudioInputTokens = 0
+		tokenUsage.AudioOutputTokens = 0
+		tokenUsage.ImageInputTokens = 0
+		tokenUsage.VideoCount = 0
+		tokenUsage.ImageCount = 0
 		tokenUsage.UsedQuota = 0
 	}
 	if tokenUsage.UsedQuota <= 0 && estimateBillable {

--- a/bfe_modules/mod_ai_token_auth/mod_ai_token_auth_test.go
+++ b/bfe_modules/mod_ai_token_auth/mod_ai_token_auth_test.go
@@ -2061,6 +2061,137 @@ func TestTokenRequestFinishHandler_EstimateRequiresCompletedResponse(t *testing.
 	}
 }
 
+// Issue #1364: when the final usage was not confirmed, the request-finish
+// guard must clear ALL billing fields. Previously only Prompt/Completion/
+// UsedQuota were cleared and a surviving CacheReadTokens was billed alone
+// (cache-read only), losing the fresh input and output charges.
+func TestTokenRequestFinishHandler_GuardClearsSubTokenFields(t *testing.T) {
+	m := NewModuleAITokenAuth()
+	client := newMockRedisClient()
+	m.redisClient = client
+
+	clusterName := "deepseek-backup"
+	model := "deepseek-v4-flash"
+	req := newTestRequestWithCluster("ak-123", "AI_product", clusterName, model)
+
+	cluster := buildTestClusterConfWithCache(model, 0.000003, 0.000009, 0.000001, 0.0000015)
+	req.SvrDataConf = &mockServerDataConf{clusters: map[string]*bfe_cluster.BfeCluster{clusterName: cluster}}
+
+	rmbPlan := &QuotaPlan{
+		Id:       "rmb-plan",
+		RedisKey: "QUOTA_AI_product-GuardClearsSubTokenFields",
+		Unit:     "RMB",
+		Quota:    100000000,
+	}
+	SetTokenAuthContext(req, &Token{Key: "ak-123", KeyId: "ak-123-id", QuotaPlans: []*QuotaPlan{rmbPlan}}, 0, nil)
+
+	// Simulate the issue #1364 failure shape: usage fields populated (e.g.
+	// by mod_body_process) but neither final usage nor completion marked.
+	ai := req.GetAiBasicInfo()
+	usage := ai.GetTokenUsage()
+	usage.PromptTokens = 0
+	usage.CompletionTokens = 0
+	usage.CacheReadTokens = 7395200
+	usage.UsedQuota = 0
+
+	res := &bfe_http.Response{StatusCode: 200, ContentLength: -1}
+	if ret := m.tokenRequestFinishHandler(req, res); ret != bfe_module.BfeHandlerGoOn {
+		t.Fatalf("expected goon, got %d", ret)
+	}
+
+	if _, ok := client.data[rmbPlan.RedisKey]; ok {
+		t.Errorf("unconfirmed final usage must not be deducted from surviving sub-token fields")
+	}
+	if usage.CacheReadTokens != 0 || usage.CacheWriteTokens != 0 ||
+		usage.PromptTokens != 0 || usage.CompletionTokens != 0 || usage.UsedQuota != 0 {
+		t.Errorf("guard must clear all billing fields, got %+v", usage)
+	}
+}
+
+// Issue #1364: a completed non-streaming Anthropic response is billed in
+// full: fresh input at input price, cache read/write at their prices,
+// output at output price.
+func TestTokenRequestFinishHandler_RMB_NonStreamingAnthropic(t *testing.T) {
+	m := NewModuleAITokenAuth()
+	client := newMockRedisClient()
+	m.redisClient = client
+
+	clusterName := "deepseek-backup"
+	model := "deepseek-v4-flash"
+	req := newTestRequestWithCluster("ak-123", "AI_product", clusterName, model)
+
+	cluster := buildTestClusterConfWithCache(model, 0.000003, 0.000009, 0.000001, 0.0000015)
+	req.SvrDataConf = &mockServerDataConf{clusters: map[string]*bfe_cluster.BfeCluster{clusterName: cluster}}
+
+	rmbPlan := &QuotaPlan{
+		Id:       "rmb-plan",
+		RedisKey: "QUOTA_AI_product-NonStreamingAnthropic",
+		Unit:     "RMB",
+		Quota:    100000000,
+	}
+	SetTokenAuthContext(req, &Token{Key: "ak-123", KeyId: "ak-123-id", QuotaPlans: []*QuotaPlan{rmbPlan}}, 0, nil)
+
+	// Parsed from an Anthropic non-stream body by the composed chain:
+	// PromptTokens is normalized to fresh + cacheRead + cacheWrite.
+	ai := req.GetAiBasicInfo()
+	usage := ai.GetTokenUsage()
+	usage.PromptTokens = 8520 // 320 fresh + 8000 cacheRead + 200 cacheWrite
+	usage.CompletionTokens = 150
+	usage.CacheReadTokens = 8000
+	usage.CacheWriteTokens = 200
+	usage.UsedQuota = 8670
+	ai.MarkFinalUsageSeen()
+	ai.MarkResponseCompleted()
+
+	res := &bfe_http.Response{StatusCode: 200, ContentLength: -1}
+	if ret := m.tokenRequestFinishHandler(req, res); ret != bfe_module.BfeHandlerGoOn {
+		t.Fatalf("expected goon, got %d", ret)
+	}
+
+	// Expected cost = 320*0.000003 + 8000*0.000001 + 200*0.0000015 + 150*0.000009
+	//               = 0.01061 yuan
+	expectedCost := quota.RmbToFixedPoint(0.01061)
+	if remaining := client.data[rmbPlan.RedisKey]; remaining != rmbPlan.Quota-expectedCost {
+		t.Errorf("expected remaining %d, got %d", rmbPlan.Quota-expectedCost, remaining)
+	}
+}
+
+// Issue #1364: when the auth style detected from the request does not
+// match the response body format (e.g. Bearer key detected as openai
+// while the backend returns an Anthropic body), the single adapter parses
+// nothing and the composed cross-protocol chain must recover the usage.
+func TestUpdateCtxByUsage_CrossProtocolFallback(t *testing.T) {
+	req := newTestRequest("", "AI_product")
+	ai := req.InitAiBasicInfo()
+	ai.AuthStyle = bfe_basic.AuthStyleOpenAI
+	ctx := &TokenAuthContext{aiBasicInfo: ai}
+
+	UpdateCtxByUsage(ctx, []byte(`{"id":"msg_01","type":"message","role":"assistant","usage":{"input_tokens":320,"output_tokens":150,"cache_read_input_tokens":8000,"cache_creation_input_tokens":200}}`))
+	usage := ai.GetTokenUsage()
+	if usage.PromptTokens != 8520 {
+		t.Errorf("expected PromptTokens 8520 (320+8000+200), got %d", usage.PromptTokens)
+	}
+	if usage.CompletionTokens != 150 {
+		t.Errorf("expected CompletionTokens 150, got %d", usage.CompletionTokens)
+	}
+	if usage.CacheReadTokens != 8000 || usage.CacheWriteTokens != 200 {
+		t.Errorf("unexpected cache tokens: %+v", usage)
+	}
+	if usage.UsedQuota != 8670 {
+		t.Errorf("expected UsedQuota 8670 (8520+150), got %d", usage.UsedQuota)
+	}
+
+	// Full cache hit with input_tokens = 0 must still be recognized.
+	ai2 := newTestRequest("", "AI_product").InitAiBasicInfo()
+	ai2.AuthStyle = bfe_basic.AuthStyleOpenAI
+	ctx2 := &TokenAuthContext{aiBasicInfo: ai2}
+	UpdateCtxByUsage(ctx2, []byte(`{"type":"message","usage":{"input_tokens":0,"output_tokens":42,"cache_read_input_tokens":5000}}`))
+	usage2 := ai2.GetTokenUsage()
+	if usage2.PromptTokens != 5000 || usage2.CacheReadTokens != 5000 || usage2.UsedQuota != 5042 {
+		t.Errorf("unexpected full-cache-hit usage: %+v", usage2)
+	}
+}
+
 func TestCalcChatCost_HighPrecision(t *testing.T) {
 	// Prices with more than 8 decimal places (from the generated model
 	// catalog) must not be truncated at config load time. The old

--- a/bfe_modules/mod_body_process/body_process.go
+++ b/bfe_modules/mod_body_process/body_process.go
@@ -21,8 +21,11 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/tidwall/gjson"
+
 	"github.com/bfenetworks/bfe/bfe_basic"
 	"github.com/bfenetworks/bfe/bfe_http"
+	"github.com/bfenetworks/bfe/bfe_model_protocol/utils"
 )
 
 // BodyProcessor 扩展中断支持
@@ -420,7 +423,7 @@ func (e *RawEvent) ToBytes() []byte {
 
 func (e *RawEvent) GetQuotaUsage() QuotaUsage {
 	data := *e
-	fields := extractUsageFields(data)
+	fields := utils.ParseUsageFieldsCrossProtocol(data)
 
 	curtoken := int64(0)
 	isguess := true
@@ -429,6 +432,16 @@ func (e *RawEvent) GetQuotaUsage() QuotaUsage {
 	} else {
 		curtoken = EstimateContentToken(string(data))
 	}
+
+	// Non-SSE payloads carry no SSE envelope: a whole-body JSON (or the
+	// usage-bearing line of an ndjson payload) that parses to a non-guess
+	// usage marks both the final usage and the response completion
+	// (issue #1364). "message" is the Anthropic non-streaming top-level
+	// type; "" covers OpenAI-style bodies without a top-level type.
+	evType := gjson.GetBytes(data, "type").String()
+	isFinalUsage := !isguess && fields.CompletionTokens > 0 &&
+		(evType == "message_delta" || evType == "message" || evType == "")
+	isTermination := isFinalUsage
 
 	return QuotaUsage{
 		PromptTokens:      fields.PromptTokens,
@@ -443,6 +456,8 @@ func (e *RawEvent) GetQuotaUsage() QuotaUsage {
 		UsedQuota:         fields.UsedQuota,
 		CurrentTokens:     curtoken,
 		IsGuess:           isguess,
+		IsFinalUsage:      isFinalUsage,
+		IsTermination:     isTermination,
 	}
 }
 

--- a/bfe_modules/mod_body_process/content_quota_usage_test.go
+++ b/bfe_modules/mod_body_process/content_quota_usage_test.go
@@ -58,6 +58,42 @@ func TestQuotaUsageProcessorProcessWithUsage(t *testing.T) {
 	}
 }
 
+// Issue #1364: a non-streaming Anthropic body (top-level type "message")
+// must mark both the final usage and the response completion, otherwise
+// the request-finish guard treats a fully parsed usage as unconfirmed.
+func TestQuotaUsageProcessorProcessAnthropicNonStreamMarks(t *testing.T) {
+	req := newTestRequest("AI_product")
+	ai := req.InitAiBasicInfo()
+	res := &bfe_http.Response{StatusCode: bfe_http.StatusOK}
+	p := NewQuotaUsageProcessor(req, res)
+
+	body := `{"id":"msg_01","type":"message","role":"assistant","content":[{"type":"text","text":"hi"}],"usage":{"input_tokens":574145,"output_tokens":109329,"cache_read_input_tokens":7395200}}`
+	events := []Event{newRawEvent(body)}
+	if _, err := p.Process(events); err != nil {
+		t.Fatalf("Process failed: %s", err)
+	}
+
+	if !ai.IsFinalUsageSeen() {
+		t.Error("expected final usage seen for non-stream Anthropic body")
+	}
+	if !ai.IsResponseCompleted() {
+		t.Error("expected response completed for non-stream Anthropic body")
+	}
+	usage := ai.GetTokenUsage()
+	if usage.PromptTokens != 7969345 {
+		t.Errorf("expected PromptTokens 7969345 (574145+7395200), got %d", usage.PromptTokens)
+	}
+	if usage.CompletionTokens != 109329 {
+		t.Errorf("expected CompletionTokens 109329, got %d", usage.CompletionTokens)
+	}
+	if usage.CacheReadTokens != 7395200 {
+		t.Errorf("expected CacheReadTokens 7395200, got %d", usage.CacheReadTokens)
+	}
+	if usage.UsedQuota != 8078674 {
+		t.Errorf("expected UsedQuota 8078674 (7969345+109329), got %d", usage.UsedQuota)
+	}
+}
+
 func TestQuotaUsageProcessorProcessEstimate(t *testing.T) {
 	req := newTestRequest("AI_product")
 	ai := req.InitAiBasicInfo()

--- a/bfe_modules/mod_body_process/llm_util.go
+++ b/bfe_modules/mod_body_process/llm_util.go
@@ -27,7 +27,6 @@ import (
 )
 
 import (
-	modelprotocol "github.com/bfenetworks/bfe/bfe_model_protocol"
 	"github.com/bfenetworks/bfe/bfe_model_protocol/utils"
 )
 
@@ -131,33 +130,9 @@ func (e *SSEEvent) GetAuditData() []byte {
 	return e.GetData()
 }
 
-// extractUsageFields extracts usage fields from one response body by
-// composing the protocol adapters: the openai adapter chain first, then
-// the anthropic (Claude) chain when no OpenAI-style prompt/completion
-// tokens are present. This mirrors the legacy all-chain extraction
-// field-for-field.
-func extractUsageFields(data []byte) modelprotocol.UsageFields {
-	fields := modelprotocol.Get(modelprotocol.ProtocolOpenAI).ExtractUsageFields(data)
-	if fields.PromptTokens == 0 && fields.CompletionTokens == 0 {
-		claude := modelprotocol.Get(modelprotocol.ProtocolAnthropic).ExtractUsageFields(data)
-		fields.PromptTokens = claude.PromptTokens
-		fields.CompletionTokens = claude.CompletionTokens
-		if fields.CacheReadTokens == 0 {
-			fields.CacheReadTokens = claude.CacheReadTokens
-		}
-		if fields.CacheWriteTokens == 0 {
-			fields.CacheWriteTokens = claude.CacheWriteTokens
-		}
-		if fields.UsedQuota == 0 {
-			fields.UsedQuota = claude.UsedQuota
-		}
-	}
-	return fields
-}
-
 func (e *SSEEvent) GetQuotaUsage() QuotaUsage {
 	data := e.GetData()
-	fields := extractUsageFields(data)
+	fields := utils.ParseUsageFieldsCrossProtocol(data)
 
 	curtoken := int64(0)
 	isguess := true
@@ -177,9 +152,12 @@ func (e *SSEEvent) GetQuotaUsage() QuotaUsage {
 	isTermination := evType == "message_stop" || strings.TrimSpace(string(data)) == "[DONE]"
 	isFinalUsage := false
 	if !isguess && fields.CompletionTokens > 0 {
-		if evType == "message_delta" || evType == "" {
-			// Anthropic message_delta, or a protocol-agnostic final usage
-			// chunk (e.g. OpenAI with stream_options.include_usage)
+		if evType == "message_delta" || evType == "message" || evType == "" {
+			// Anthropic message_delta, the Anthropic non-streaming
+			// top-level type "message", or a protocol-agnostic final
+			// usage chunk (e.g. OpenAI with stream_options.include_usage).
+			// Without "message" the final usage of a non-streaming
+			// Anthropic JSON body would never be recognized (issue #1364).
 			isFinalUsage = true
 		}
 	}

--- a/bfe_modules/mod_body_process/llm_util_test.go
+++ b/bfe_modules/mod_body_process/llm_util_test.go
@@ -248,6 +248,71 @@ func TestSSEEventDecoderEOF(t *testing.T) {
 	}
 }
 
+func TestRawEventGetQuotaUsage_CompletionFlags(t *testing.T) {
+	tests := []struct {
+		name            string
+		data            string
+		wantTermination bool
+		wantFinalUsage  bool
+	}{
+		{
+			// Anthropic non-streaming body (chunked): top-level type "message"
+			// is both the final usage and the response completion (issue #1364)
+			name:            "anthropic non-stream message",
+			data:            `{"type":"message","usage":{"input_tokens":574145,"output_tokens":109329,"cache_read_input_tokens":7395200}}`,
+			wantTermination: true,
+			wantFinalUsage:  true,
+		},
+		{
+			// OpenAI-style non-streaming body without a top-level type
+			name:            "openai non-stream body",
+			data:            `{"usage":{"prompt_tokens":100,"completion_tokens":50,"total_tokens":150}}`,
+			wantTermination: true,
+			wantFinalUsage:  true,
+		},
+		{
+			// Body without usage stays a guess: neither final nor termination
+			name:            "body without usage",
+			data:            `{"id":"chatcmpl-1","choices":[{"message":{"content":"hi"}}]}`,
+			wantTermination: false,
+			wantFinalUsage:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ev := RawEvent([]byte(tt.data))
+			q := ev.GetQuotaUsage()
+			if q.IsTermination != tt.wantTermination {
+				t.Errorf("IsTermination = %v, want %v", q.IsTermination, tt.wantTermination)
+			}
+			if q.IsFinalUsage != tt.wantFinalUsage {
+				t.Errorf("IsFinalUsage = %v, want %v", q.IsFinalUsage, tt.wantFinalUsage)
+			}
+		})
+	}
+}
+
+func TestRawEventGetQuotaUsage_AnthropicNonStreamFields(t *testing.T) {
+	ev := RawEvent([]byte(`{"type":"message","usage":{"input_tokens":320,"output_tokens":150,"cache_read_input_tokens":8000,"cache_creation_input_tokens":200}}`))
+	q := ev.GetQuotaUsage()
+	if q.PromptTokens != 8520 {
+		t.Errorf("expected PromptTokens 8520 (320+8000+200), got %d", q.PromptTokens)
+	}
+	if q.CompletionTokens != 150 {
+		t.Errorf("expected CompletionTokens 150, got %d", q.CompletionTokens)
+	}
+	if q.CacheReadTokens != 8000 || q.CacheWriteTokens != 200 {
+		t.Errorf("unexpected cache tokens: %+v", q)
+	}
+	if q.IsGuess {
+		t.Error("expected IsGuess false")
+	}
+	if !q.IsFinalUsage || !q.IsTermination {
+		t.Errorf("expected final usage and termination for non-stream Anthropic body, got final=%v termination=%v", q.IsFinalUsage, q.IsTermination)
+	}
+}
+
 func TestSSEEventGetQuotaUsage_CompletionFlags(t *testing.T) {
 	tests := []struct {
 		name            string
@@ -286,6 +351,14 @@ func TestSSEEventGetQuotaUsage_CompletionFlags(t *testing.T) {
 			// OpenAI final chunk with stream_options.include_usage
 			name:            "openai final usage chunk",
 			data:            `{"id":"chatcmpl-1","choices":[],"usage":{"prompt_tokens":10,"completion_tokens":20,"total_tokens":30}}`,
+			wantTermination: false,
+			wantFinalUsage:  true,
+		},
+		{
+			// Anthropic non-streaming top-level type: the whole-body JSON is
+			// the final usage (issue #1364)
+			name:            "anthropic non-stream message",
+			data:            `{"type":"message","usage":{"input_tokens":320,"output_tokens":150,"cache_read_input_tokens":8000}}`,
 			wantTermination: false,
 			wantFinalUsage:  true,
 		},

--- a/docs/zh_cn/modifications/2026-09-09-issue-1364-anthropic-nonstream-billing-fix/design-changes.md
+++ b/docs/zh_cn/modifications/2026-09-09-issue-1364-anthropic-nonstream-billing-fix/design-changes.md
@@ -1,0 +1,204 @@
+# BFE Issue #1364 修复方案
+
+- Issue: https://github.com/bfenetworks/bfe/issues/1364
+- 缺陷：Anthropic 非流式（chunked）响应在 #1352 守卫后 RMB 计费只按 cache_read 入账，漏计未命中输入与输出（实测漏计 4.65x）
+- 代码库：`bfe/`（已对照当前代码逐条核实，行号基于当前 HEAD）
+
+## 一、根因（三层叠加，缺一不可）
+
+### 第 1 层（直接缺陷）：#1352 守卫漏清 cache/audio/image 子字段
+
+`bfe_modules/mod_ai_token_auth/mod_ai_token_auth.go:243-247`：
+
+```go
+if !ctx.aiBasicInfo.IsFinalUsageSeen() && !estimateBillable {
+    tokenUsage.PromptTokens = 0
+    tokenUsage.CompletionTokens = 0
+    tokenUsage.UsedQuota = 0
+    // ← CacheReadTokens / CacheWriteTokens / Audio* / Image* / VideoCount / ImageCount 全部漏清
+}
+```
+
+`TokenUsage` 共 12 个字段（`bfe_basic/request_ai_basic.go:59-71`），守卫只清了 3 个。
+随后 `calcCostUnits` → `calcChatCost`（`mod_ai_token_auth.go:591-699`）拿到
+`{Prompt:0, Completion:0, CacheRead:N}`：`normalInput = 0 - N → 截断 0`，`normalOutput = 0`，
+只剩 `cacheRead × cache_read_price` 入账 —— 与线上"只收缓存命中"现象精确吻合。
+
+### 第 2 层（触发条件）：Anthropic 非流式 JSON 永不标记 final-usage / response-completed
+
+`MarkFinalUsageSeen()` 的两个来源对非流式 Anthropic JSON 均失效：
+
+- `mod_body_process/content_quota_usage.go:44` 要求 `rquota.IsFinalUsage`；
+  `isFinalUsage`（`mod_body_process/llm_util.go:179-185`）只认顶层
+  `type=="message_delta" || ""`，Anthropic 非流式顶层是 `"type":"message"` → 永不标记。
+- `MarkResponseCompleted()` 只认 `message_stop` / `[DONE]`（`llm_util.go:177`），
+  非流式单 JSON 事件同样打不上 → `estimateBillable`（`mod_ai_token_auth.go:242`）也为 false。
+- `tokenReadResponseHandler`（`mod_ai_token_auth.go:171`）要求 `res.ContentLength >= 0`；
+  chunked 响应 `ContentLength == -1` → 整段跳过。
+
+但组合解析链 `extractUsageFields`（`mod_body_process/llm_util.go:139-156`，
+OpenAI 链 → Claude 链回退）对 Anthropic body 工作正常，已把全部 usage 字段（含 CacheRead）
+写入上下文 —— "值填上了、标记没打上"，守卫一清就只剩 cache_read。
+
+### 第 3 层（使能回归，commit 286b4e0a）：单适配器丢失跨协议兜底
+
+`UpdateCtxByUsage`（`mod_ai_token_auth.go:116-163`）把 usage 解析从组合链改为
+`modelprotocol.Get(ctx.aiBasicInfo.AuthStyle).ExtractUsageFields(data)` 单适配器（`:121`）。
+OpenAI 链只认 `usage.prompt_tokens / total_tokens`（`bfe_model_protocol/utils/usage_parse.go:42-71`），
+AuthStyle 与响应体格式错配（如 Bearer → ProtocolOpenAI + Anthropic body，DeepSeek 官方
+key 为 `sk-` 前缀必然走这条路）时解析全零 → `UsedQuota=0` → 连
+`tokenReadResponseHandler:178` 的打标也失效。旧组合链任何 body 都能解出 `UsedQuota>0`。
+
+此前测试全过的原因：既有受控后端返回带 Content-Length 的小 JSON（走
+tokenReadResponseHandler 正常打标）；SSE 靠 `message_delta` 打标；
+"chunked + 非流式 Anthropic"从未被覆盖，真实 DeepSeek 流量恰好落入盲区。
+
+## 二、修复步骤
+
+### 步骤 1（必改，止血）：守卫清零全部计费字段
+
+文件：`bfe_modules/mod_ai_token_auth/mod_ai_token_auth.go`，`:243-247`
+
+将守卫改为清零 `TokenUsage` 的全部 token 字段（保留 `UsedCost`，其下有
+`UsedCost <= 0` 判断，会随重新计算覆盖）：
+
+```go
+if !ctx.aiBasicInfo.IsFinalUsageSeen() && !estimateBillable {
+    tokenUsage.PromptTokens = 0
+    tokenUsage.CompletionTokens = 0
+    tokenUsage.CacheReadTokens = 0
+    tokenUsage.CacheWriteTokens = 0
+    tokenUsage.AudioInputTokens = 0
+    tokenUsage.AudioOutputTokens = 0
+    tokenUsage.ImageInputTokens = 0
+    tokenUsage.VideoCount = 0
+    tokenUsage.ImageCount = 0
+    tokenUsage.UsedQuota = 0
+}
+```
+
+效果：未确认完成的响应不再按残存子字段收 RMB（宁漏收、不错收）。
+注意：`ImageCount/VideoCount` 分支在 `content_quota_usage.go:44` 有独立打标路径
+（`!IsGuess && (ImageCount>0 || VideoCount>0)`），清零它们不会改变"图片/视频
+生成已成功即计费"的语义，因为那条路径会置 `IsFinalUsageSeen()`。
+
+### 步骤 2（必改，治本）：`isFinalUsage` 认可非流式 Anthropic JSON
+
+文件：`bfe_modules/mod_body_process/llm_util.go`，`:179-185`
+
+```go
+if evType == "message_delta" || evType == "message" || evType == "" {
+    isFinalUsage = true
+}
+```
+
+`gjson` 只读顶层 `type`，SSE 的 `message_start`（顶层 `event: message_start`，
+JSON 里无顶层 `type` 字段或嵌套在 `message.` 下）不受影响；`message_stop`
+分支本就不满足 `CompletionTokens > 0` 以外的条件组合，保持不变。
+
+同时把 `isTermination`（`:177`）扩展为非流式完成信号，使
+`MarkResponseCompleted()` 对非 SSE 单 JSON 生效：
+
+```go
+isTermination := evType == "message_stop" ||
+    strings.TrimSpace(string(data)) == "[DONE]" ||
+    (evType == "message" && !isStreaming) // 非流式 Anthropic 整体即一条完成事件
+```
+
+实现上更简单稳妥的做法：在 `QuotaUsageProcessor.Process` 中，当事件是"整个
+响应体的单 JSON 且解析出非 guess usage"时同时调用 `MarkResponseCompleted()`，
+而不是改动 `isTermination` 的纯数据语义（见步骤 4 的推荐实现）。
+
+### 步骤 3（修回归）：恢复跨协议解析兜底
+
+文件：`bfe_modules/mod_ai_token_auth/mod_ai_token_auth.go`，`:116-163`
+
+`UpdateCtxByUsage` 保持单适配器优先（正常路径零开销），单适配器结果全零时
+回退组合链，恢复 286b4e0a 之前的"响应格式无关"语义：
+
+```go
+adapter := modelprotocol.Get(ctx.aiBasicInfo.AuthStyle)
+fields := adapter.ExtractUsageFields(data)
+if fields.UsedQuota == 0 && fields.PromptTokens == 0 &&
+    fields.CompletionTokens == 0 && fields.ImageCount == 0 && fields.VideoCount == 0 {
+    // auth style 与响应体格式错配（如 Bearer→OpenAI 适配器 + Anthropic body）：
+    // 回退到 OpenAI→Claude 组合链，恢复 286b4e0a 之前的跨协议解析语义。
+    fields = extractUsageFieldsCrossProtocol(data) // 上提 mod_body_process 的 extractUsageFields
+}
+```
+
+为避免 `bfe_modules` 与 `bfe_model_protocol` 之间出现新的依赖方向，建议把
+组合链逻辑下沉到 `bfe_model_protocol/utils`（如新增
+`ParseUsageFieldsWithFallback(data)`，内部 = OpenAI 链 + Claude 链回退），
+`mod_body_process/llm_util.go:139-156` 与 `mod_ai_token_auth.go` 共用一份实现，
+杜绝两处逻辑再次分叉。
+
+### 步骤 4（加固）：非流式单 JSON 事件处理完后标记响应完成
+
+文件：`bfe_modules/mod_body_process/content_quota_usage.go`，`Process`
+
+对"整个响应体作为一个事件"的非 SSE 路径（`RawEvent` / 整条 body 一次性 decode），
+在解析出非 guess usage 后追加 `MarkResponseCompleted()`，使
+`estimateBillable`（`mod_ai_token_auth.go:242`）对正常完成的非流式响应生效，
+`#1352` 守卫只拦截真正未完成/被截断的响应：
+
+```go
+if rquota.IsFinalUsage || (!rquota.IsGuess && (rquota.ImageCount > 0 || rquota.VideoCount > 0)) {
+    caf.aiBasicInfo.MarkFinalUsageSeen()
+    if !isStreamingResponse { // 非 SSE：单事件即完整响应
+        caf.aiBasicInfo.MarkResponseCompleted()
+    }
+}
+```
+
+`isStreamingResponse` 可由 `Content-Type: text/event-stream` 或 decoder 类型判定；
+若判定点不便获取，可退而求其次：事件数为 1 且 body 是合法完整 JSON 时标记完成。
+
+## 三、回归测试
+
+新增/修改用例（均放在被测代码旁的 `_test.go`，沿用 `testing` + `testify`）：
+
+1. `mod_ai_token_auth` 单元测试：构造
+   `{PromptTokens:0, CompletionTokens:0, CacheReadTokens:N, UsedQuota:0}` +
+   `IsFinalUsageSeen()==false` + `IsResponseCompleted()==false` 的上下文，
+   断言 `tokenRequestFinishHandler` 后 `UsedCost == 0`（止血守卫生效）。
+2. `mod_body_process` 单元测试：SSE 事件序列注入顶层 `type:"message"` 的
+   Anthropic 非流式 JSON（模拟整 body 单事件），断言 `MarkFinalUsageSeen()`
+   与 `MarkResponseCompleted()` 均被调用。
+3. `mod_ai_token_auth` 单元测试：`UpdateCtxByUsage` 传入 AuthStyle=OpenAI +
+   Anthropic 格式 body，断言回退组合链后 `UsedQuota>0` 且各子字段正确。
+4. E2E（`bfe/tests/integration` SC03）：新增
+   `TestTC16_RMBQuotaDeduction_Anthropic_NonStream_Chunked`（非流式 + 无
+   Content-Length(chunked) + Anthropic 格式 body）与
+   `TestTC17_RMBQuotaDeduction_Anthropic_NonStream_ContentLength`（带 Content-Length
+   臂，验证跨协议回退），断言 RMB 扣款 = input全价×未命中 + cache_read×缓存价
+   + output×输出价；既有 SSE 臂与 Cache 计费臂防止误伤。
+
+验证命令：`cd bfe && make test`（go test -cover ./... + go vet ./...）。
+
+## 四、修复后正确计费路径（目标行为）
+
+非流式 Anthropic（chunked）请求：
+
+1. `extractUsageFields`（或单适配器+回退）解析出完整 usage → 全部字段入 `TokenUsage`；
+2. `isFinalUsage` 认可 `type:"message"` → `MarkFinalUsageSeen()`；
+   单事件非 SSE → `MarkResponseCompleted()`；
+3. `tokenRequestFinishHandler`：守卫不触发（final usage 已见）；
+4. `calcChatCost`：`normalInput = prompt − cacheRead − cacheWrite`（未命中部分按
+   input 全价）、`cacheRead × cache_read价`、`normalOutput × output价` ——
+   与 DeepSeek 后台账单对齐（如 issue 中 0.8612 + 0.3698 + 0.4920 = 1.7230 的分解）。
+
+## 五、实施记录（2026-09-09）
+
+已按上述方案实施，变更文件：
+
+| 文件 | 改动 |
+| --- | --- |
+| `bfe_model_protocol/utils/usage_parse.go` | 新增 `ParseUsageFieldsCrossProtocol`（OpenAI 链 → prompt/completion 全零时回落 Anthropic 链），组合链唯一实现 |
+| `bfe_modules/mod_ai_token_auth/mod_ai_token_auth.go` | ① 守卫清零全部 10 个计费字段（issue #1364）；② `UpdateCtxByUsage` 单适配器结果全零时回退 `ParseUsageFieldsCrossProtocol` |
+| `bfe_modules/mod_body_process/llm_util.go` | 删除本地 `extractUsageFields` 改为调用 utils 共用实现；`isFinalUsage` 增加顶层 `type:"message"` |
+| `bfe_modules/mod_body_process/body_process.go` | `RawEvent.GetQuotaUsage` 非 guess usage 置 `IsFinalUsage`/`IsTermination`（非 SSE 单 JSON 即完整响应） |
+| 单元测试 | `utils/usage_parse_test.go`（新增）；`mod_ai_token_auth_test.go`：`TestUpdateCtxByUsage_CrossProtocolFallback`、`TestTokenRequestFinishHandler_GuardClearsSubTokenFields`、`TestTokenRequestFinishHandler_RMB_NonStreamingAnthropic`；`llm_util_test.go`：`TestRawEventGetQuotaUsage_*`、SSE CompletionFlags 增加 `message` 臂；`content_quota_usage_test.go`：`TestQuotaUsageProcessorProcessAnthropicNonStreamMarks` |
+| 集成测试 | `bfe/tests/integration` SC03 新增 `TestTC16_RMBQuotaDeduction_Anthropic_NonStream_Chunked`（非流式+chunked+Anthropic body）、`TestTC17_RMBQuotaDeduction_Anthropic_NonStream_ContentLength`（带 Content-Length 臂，验证跨协议回退），扣减断言 900000 定点单位；`tests/integration/common/mock_backend.go` 新增 `NoContentLength` 开关（flush 响应头强制 chunked）；设计文档 `TC-16`/`TC-17` 及场景说明已同步 |
+
+验证：`go test ./bfe_model_protocol/... ./bfe_modules/mod_body_process/... ./bfe_modules/mod_ai_token_auth/...` 全部通过；`bfe/tests/integration` SC03 集成测试 TC-01~TC-17 全部通过。

--- a/docs/zh_cn/sys_design/model_protocol_adapter.md
+++ b/docs/zh_cn/sys_design/model_protocol_adapter.md
@@ -161,7 +161,7 @@ http_conn.serveRequest()
 | 版本头注入 | `reverseproxy.go` 硬编码 `anthropic-version` | 适配器 `ExtraHeaders`，显式携带优先（TC-07） |
 | 协议校验 | `clusterSupportsAuthStyle` | `modelprotocol.Supports`（语义不变） |
 | 流式 usage | `SSEEvent/RawEvent.GetQuotaUsage` 各一份全链 | 适配器字段链 + 调用方累加语义保留 |
-| 非流式 usage | `UpdateCtxByUsage` 一份全链 | 同上 |
+| 非流式 usage | `UpdateCtxByUsage` 一份全链 | 按 `AuthStyle` 取单适配器；结果全零时回退两阶段组合（issue #1364） |
 | fallback 判定 | `shouldTriggerFallback` 纯状态码白名单 | 前置 `ErrorNormalizer` seam（默认返回 nil → 白名单，行为不变） |
 
 `ModelProtocols` 未知协议名的加载校验挂在 `bfe_server/bfe_confdata_load.go` 的 `InitDataLoad`（启动失败）与 `serverDataConfReload`（热加载拒绝且不换配置）；`bfe_config` 不依赖 `bfe_model_protocol`。
@@ -181,11 +181,11 @@ http_conn.serveRequest()
 - **openai 适配器**：OpenAI 主链 + DeepSeek + Responses fallback（无 Claude 链）；
 - **anthropic 适配器**：Claude 链（含 prompt 归一）。2026-09-04 起增加真实流式报文结构解析（issue #1352）：Anthropic 流式 `message_start` 的初始 usage 位于 `message.usage.*`（此前只解析顶层 `usage.*`），`message_delta` 的最终 usage 位于顶层 `usage.*`，两条路径均支持。
 
-等价性：各链互斥（OpenAI 系响应有 `prompt_tokens`；Claude 有 `input_tokens`；全零→estimate），按协议拆分后与全链结果逐字段等价。
+等价性：各链互斥（OpenAI 系响应有 `prompt_tokens`；Claude 有 `input_tokens`；全零→estimate），按协议拆分后与全链结果逐字段等价。**例外**（issue #1364）：当鉴权识别出的协议与响应体实际格式错配（如 Bearer→openai 适配器 + Anthropic body）时，单适配器解析全零、不等价于旧全链；该场景由 `UpdateCtxByUsage` 的全零回退兜底（见 5.2）。
 
 ### 5.2 累加语义留在调用方
 
-- `UpdateCtxByUsage` 按 `AuthStyle` 取适配器，后续 `used>0 / else if prompt>0...` 分支逐行保留（写 `bfe_basic.TokenUsage`）；
+- `UpdateCtxByUsage` 按 `AuthStyle` 取适配器，后续 `used>0 / else if prompt>0...` 分支逐行保留（写 `bfe_basic.TokenUsage`）；**跨协议兜底**（issue #1364）：单适配器结果全零（`UsedQuota`/`PromptTokens`/`CompletionTokens`/`ImageCount`/`VideoCount` 均为 0，典型场景：Bearer 鉴权被识别为 OpenAI 协议、后端返回 Anthropic 格式 body）时，回退到与 `mod_body_process` 相同的两阶段组合链（openai 链 → prompt/completion 全零时回落 anthropic 链）再解析一次，恢复收敛前"响应格式无关"语义，避免 `UsedQuota = 0` 导致最终 usage 标记失效、计费漏项；
 - `SSEEvent/RawEvent.GetQuotaUsage` 签名无参数拿不到 `AuthStyle`，经共享 helper `extractUsageFields` 做两阶段组合（openai 链 → prompt/completion 全零时回落 anthropic 链，含 carry-in 合并），`isguess`/`EstimateContentToken` 逻辑原样；
 - 扣费准确性依赖此约定：迁移时逐字段回归（流式累加、estimate 模式、Anthropic prompt 归一）。
 
@@ -223,4 +223,5 @@ http_conn.serveRequest()
 - **透传原则**：适配层只做边缘适配（认证/版本头/usage/错误），不做请求/响应体协议翻译；
 - **兜底一致性**：`Get` 对未知协议回落 openai、`Supports` 空列表默认 openai，与历史行为一致；未知协议名在配置加载期报错（暴露既有配置错误）；
 - **病态响应体**：同一 usage 同时混含 DeepSeek 与 Claude 字段且缺 `prompt_tokens` 时，事件侧两阶段合并与旧全链可能有差异——真实 provider 不会混合两套字段，未做特殊处理；
+- **AuthStyle 与响应体格式错配**（issue #1364）：鉴权协议由请求头/路径识别，响应体格式由后端实际返回决定，两者可能不一致（如 DeepSeek 官方 Key 走 Anthropic 兼容端点但识别为 openai）。此时单适配器解析全零，依赖 `UpdateCtxByUsage` 的全零回退组合链兜底；`mod_body_process` 事件侧本就走组合链，不受影响；
 - **per-cluster 认证变体**（如 Azure OpenAI 的 `api-key` header）：当前 `InjectAuth` 未承载 per-cluster 参数，需要时另起评审扩展接口。

--- a/docs/zh_cn/sys_design/rmb_quota.md
+++ b/docs/zh_cn/sys_design/rmb_quota.md
@@ -340,6 +340,7 @@ type AiBasicInfo struct {
 
 - `mod_body_process`（流式）在解析到最终 usage / 终止事件时置位，见 7.4。
 - `mod_ai_token_auth`（非流式）在 `tokenReadResponseHandler` 完整读取响应体后置位，见 7.4。
+- **非流式 Anthropic JSON 视同最终 usage**（issue #1364）：顶层 `type:"message"` 且解析出非 guess usage（`output_tokens > 0`）的整体响应，与 SSE `message_delta` 等价，置位 `finalUsageSeen`；整条 body 作为单个事件处理完成时同时置位 `responseCompleted`。否则 Anthropic 非流式响应（尤其是 chunked、`ContentLength = -1`）两个标记都打不上，会落入"未完成"守卫。
 - 计费语义：EstimateToken 的估算值仅在 `responseCompleted` 为 true 时可计费；客户端中断（`ErrClientWrite` / `ErrClientClose` / `ErrClientReset`）且未拿到最终 usage 的请求零扣费，已拿到最终 usage 的按实际 usage 扣费，见 7.5。
 
 ## 7. 请求运行时改动
@@ -468,8 +469,11 @@ SSE 事件的 `QuotaUsage` 携带 `IsFinalUsage` / `IsTermination` 标志（`bfe
 | Anthropic `message_start`（初始 usage，`output_tokens = 0`） | false | false |
 | Anthropic `message_delta`（最终 usage，`output_tokens > 0`） | true | false |
 | Anthropic `message_stop` | - | true |
+| Anthropic 非流式整体响应（顶层 `type:"message"`，`output_tokens > 0`，整条 body 单事件） | true | true（issue #1364） |
 | OpenAI 最终 usage chunk（`stream_options.include_usage`，无 `type` 且 `completion_tokens > 0`） | true | false |
 | OpenAI `[DONE]` | - | true |
+
+> 说明（issue #1364）：`isFinalUsage` 判定从"`type == "message_delta" || ""`"扩展为同时认可顶层 `type:"message"`。`gjson` 只读顶层 `type`，SSE `message_start` 事件的顶层无 `type` 字段（嵌套在 `message.` 下），不受影响。非 SSE 路径整条 body 作为单事件处理完成时，`QuotaUsageProcessor` 额外置位 `MarkResponseCompleted()`，使正常完成的非流式响应可计费、真正未完成/被截断的响应仍被守卫拦截。
 
 `QuotaUsageProcessor.Process` 据此在 `AiBasicInfo` 上置位 `MarkFinalUsageSeen()` / `MarkResponseCompleted()`（图片/视频按次计费事件同样置位 `finalUsageSeen`），并做两件与计费正确性相关的事：
 
@@ -486,9 +490,11 @@ DeepSeek 与 OpenAI Responses API 在 usage 中使用与常规 OpenAI/Claude 不
 
 BFE 在以下三处解析中，当 `cache_read_tokens` / `cache_read_input_tokens` 为 0 时，会依次 fallback 到上述字段（2026-09 起，字段链实现已收敛到协议适配层 `bfe/bfe_model_protocol/`，见 `sys_design/model_protocol_adapter.md`；三处调用方仅保留累加语义，行为不变）：
 
-- `bfe_modules/mod_ai_token_auth/mod_ai_token_auth.go`：`UpdateCtxByUsage`（非流式，按 `AuthStyle` 委托适配器 `ExtractUsageFields`）
+- `bfe_modules/mod_ai_token_auth/mod_ai_token_auth.go`：`UpdateCtxByUsage`（非流式，按 `AuthStyle` 委托适配器 `ExtractUsageFields`；单适配器结果全零时回退 OpenAI→Claude 组合链，见下）
 - `bfe_modules/mod_body_process/llm_util.go`：`SSEEvent.GetQuotaUsage`（SSE 流式，经共享 helper `extractUsageFields`）
 - `bfe_modules/mod_body_process/body_process.go`：`RawEvent.GetQuotaUsage`（RawEvent 非流式，同上）
+
+> 跨协议兜底（issue #1364）：`UpdateCtxByUsage` 虽按 `AuthStyle` 取**单**适配器，但当解析结果全零（`UsedQuota`/`PromptTokens`/`CompletionTokens`/`ImageCount`/`VideoCount` 均为 0，典型场景：Bearer 鉴权被识别为 OpenAI 协议、后端却返回 Anthropic 格式 body，如 DeepSeek 官方 `sk-` Key 走 Anthropic 兼容端点）时，回退到与 `mod_body_process` 相同的 OpenAI→Claude 组合链再解析一次，恢复 286b4e0a 收敛前的"响应格式无关"语义，避免 `UsedQuota = 0` 导致最终 usage 标记失效。
 
 这样无论后端返回哪种字段名，`TokenUsage.CacheReadTokens` 都能被正确填充，后续 `calcChatCost` 按统一逻辑拆分计费。
 
@@ -531,11 +537,21 @@ func (m *ModuleAITokenAuth) tokenRequestFinishHandler(req *bfe_basic.Request, re
     // EstimateToken 播种的值（鉴权阶段按请求体长度估算的 prompt、
     // 流式按内容长度累加的 completion）只有响应正常完成时才可计费。
     // calcCostUnits 直接按 token 字段计费、与 UsedQuota 守卫无关，
-    // 因此不可计费时必须把估算字段清零，否则鉴权阶段的估算值会流向扣费。
+    // 因此不可计费时必须把全部计费字段清零，否则鉴权阶段的估算值
+    // 或残存的子 token 字段（cache/audio/image）会流向扣费（issue #1364：
+    // 守卫曾只清 Prompt/Completion/UsedQuota，导致 Anthropic 非流式响应
+    // 被守卫清零后仅剩 CacheReadTokens，RMB 计费只收缓存命中）。
     estimateBillable := ctx.aiBasicInfo.IsAllowEstimateToken() && ctx.aiBasicInfo.IsResponseCompleted()
     if !ctx.aiBasicInfo.IsFinalUsageSeen() && !estimateBillable {
         tokenUsage.PromptTokens = 0
         tokenUsage.CompletionTokens = 0
+        tokenUsage.CacheReadTokens = 0
+        tokenUsage.CacheWriteTokens = 0
+        tokenUsage.AudioInputTokens = 0
+        tokenUsage.AudioOutputTokens = 0
+        tokenUsage.ImageInputTokens = 0
+        tokenUsage.VideoCount = 0
+        tokenUsage.ImageCount = 0
         tokenUsage.UsedQuota = 0
     }
     if tokenUsage.UsedQuota <= 0 && estimateBillable {
@@ -577,7 +593,7 @@ func (m *ModuleAITokenAuth) tokenRequestFinishHandler(req *bfe_basic.Request, re
 }
 ```
 
-计费判定规则汇总（issue #1352）：
+计费判定规则汇总（issue #1352、#1364）：
 
 | 场景 | finalUsageSeen | 扣费 |
 |------|----------------|------|
@@ -585,6 +601,9 @@ func (m *ModuleAITokenAuth) tokenRequestFinishHandler(req *bfe_basic.Request, re
 | 正常完成，无 usage + EstimateToken | false（responseCompleted=true） | 按估算计费 |
 | 客户端中断/写失败，未拿到最终 usage | false | 零扣费 |
 | 客户端中断/写失败，已拿到最终 usage | true | 按实际 usage |
+| 非流式 Anthropic（chunked）完整响应，有 usage | true（#1364 起，`type:"message"` 视同最终 usage） | 按实际 usage（未命中输入 + cache read/write + 输出全额） |
+
+> 说明（issue #1364）：修复前 Anthropic 非流式（尤其 chunked）响应既无 `finalUsageSeen` 也无 `responseCompleted`，落入"不可计费"守卫；但守卫只清 `PromptTokens`/`CompletionTokens`/`UsedQuota`，`CacheReadTokens` 等子字段幸存，`calcChatCost` 对其按 `cache_read_input_token_cost` 计费，导致 RMB 只收缓存命中、漏计未命中输入与输出（实测漏计约 4.65x）。修复后守卫清零全部计费字段，并通过最终 usage 认可 + 完成置位让正常完成的非流式响应按实际 usage 全额计费。
 
 ### 7.6 成本计算辅助方法
 
@@ -1190,7 +1209,9 @@ return {yuan, frac}
      - 覆盖 Anthropic 高 cache 命中场景（`cache_read_tokens > prompt_tokens`）不再被截断，cache 按实际值计费；
      - 覆盖 `tokenRequestFinishHandler` 对 `/count_tokens` 端点跳过扣费；
      - 覆盖 `HandleRequestFinish` 多次触发时仅扣费一次（`deducted` 幂等标记）；
-     - 覆盖客户端中断场景（issue #1352）：`ErrClientWrite` 且未拿到最终 usage 时零扣费（`EstimateToken` 开/关一致）、已拿到最终 usage 后中断按实际 usage 扣费、响应未完成时估算不生效（`TestTokenRequestFinishHandler_ClientAbort*` 系列）。
+     - 覆盖客户端中断场景（issue #1352）：`ErrClientWrite` 且未拿到最终 usage 时零扣费（`EstimateToken` 开/关一致）、已拿到最终 usage 后中断按实际 usage 扣费、响应未完成时估算不生效（`TestTokenRequestFinishHandler_ClientAbort*` 系列）；
+     - 覆盖守卫清零完整性（issue #1364）：构造 `{PromptTokens:0, CompletionTokens:0, CacheReadTokens:N, UsedQuota:0}` 且 `IsFinalUsageSeen()==false`、`IsResponseCompleted()==false` 的上下文，断言 `tokenRequestFinishHandler` 后 `UsedCost == 0`（残存子字段不得流向扣费）；
+     - 覆盖跨协议兜底（issue #1364）：`UpdateCtxByUsage` 传入 `AuthStyle=openai` + Anthropic 格式 body（`usage.input_tokens`/`cache_read_input_tokens`/`output_tokens`），断言回退组合链后 `UsedQuota > 0` 且 prompt/completion/cache 子字段正确。
    - `ActiveTierName`：验证北京时区周一 10:00 命中 `peak`、周一 13:00 未命中、周六 10:00 未命中、周一 18:00 不命中（左闭右开）。
    - `GetPrice`：验证命中 `peak` 时取 `TierPrices.peak`、未命中时 fallback 到 `Prices`、tier 中未配置某键时 fallback 到默认价格；验证超过 8 位小数的价格（如 `7.6234102728e-08`）加载后不被截断。
 
@@ -1211,6 +1232,8 @@ return {yuan, frac}
    - 测试 Anthropic `/count_tokens` 端点不计费：请求 `/anthropic/v1/messages/count_tokens`，验证 RMB 与 token 配额均不被扣减；
    - 测试计费幂等场景：模拟 `HandleRequestFinish` 被触发两次，验证 Redis 余额只扣减一次；
    - 测试客户端中断场景（issue #1352，集成测试场景 SC12）：EstimateToken = true，客户端在 `message_start` 后发送 TCP RST，验证零扣费；收到最终 usage 后中断，验证仍按实际 usage 扣费；完整 SSE 流计费不变；
+   - 测试非流式 Anthropic 计费场景（issue #1364，新增计费矩阵臂）：后端返回 chunked（无 `Content-Length`）的 Anthropic 格式非流式 body（顶层 `type:"message"`，`usage` 含 `input_tokens`/`cache_read_input_tokens`/`output_tokens`），验证 `MarkFinalUsageSeen()`/`MarkResponseCompleted()` 均置位，RMB 扣款 = 未命中输入 × `input_cost_per_token` + cache_read × `cache_read_input_token_cost` + 输出 × `output_cost_per_token`，与上游账单对齐；同时保留 SSE 臂与带 `Content-Length` 臂防止误伤；
+   - 测试 AuthStyle 与响应体格式错配场景（issue #1364）：Bearer 鉴权（识别为 OpenAI 协议）+ Anthropic 格式 body，验证 `UpdateCtxByUsage` 回退组合链后按实际 usage 全额计费；
    - 测试分时段计费场景：`ModelTable` 配置 `Tiers` 与 `TierPrices`；分别在北京时间高峰时段（如周一 10:00）与非高峰时段（如周一 13:00 或周六 10:00）发起请求，验证 Redis 扣减金额分别按 `TierPrices.peak` 与默认 `Prices` 计算。
    - 测试分时段 + cache 命中组合场景：高峰时段且后端返回 `usage.cache_read_tokens`（或 DeepSeek 的 `usage.prompt_cache_hit_tokens` / `usage.prompt_tokens_details.cached_tokens`），验证缓存命中部分按 `TierPrices.peak.cache_read_input_token_cost` 计费，未命中部分按 `TierPrices.peak.input_cost_per_token` 计费。
 
@@ -1232,3 +1255,4 @@ return {yuan, frac}
    - `count_tokens` 端点此前被误扣费，修复后该端点不再扣费，运营侧需在计费对账层单独处理历史差异；
    - `deducted` 幂等标记仅防止同一请求生命周期内的重复扣费，不跨请求生效，不影响正常流量。
 10. **EstimateToken 语义收窄**（issue #1352）：`EstimateToken = true` 播种的估算值仅在响应正常完成时计费；客户端中断（RST/断开/写客户端失败）且未拿到最终 usage 的请求零扣费，已拿到最终 usage 的按实际 usage 扣费。客户端中断请求的收费金额会 **下降**（从按全量估算变为零扣费或按实际 usage），历史多扣需在计费对账层单独处理。
+11. **非流式 Anthropic 计费修复**（issue #1364）：非流式 Anthropic（尤其 chunked）响应此前因最终 usage / 完成标记缺失 + 守卫漏清子字段，RMB 只按 `cache_read_input_token_cost` 收缓存命中，漏计未命中输入与输出（实测漏计约 4.65x）。修复后该场景计费金额会 **上升至正确全额**（未命中输入 + cache read/write + 输出），与上游（DeepSeek）账单对齐；守卫语义为"宁漏收、不错收"——未确认完成的响应全部计费字段清零，不再产生部分字段入账。

--- a/tests/integration/common/mock_backend.go
+++ b/tests/integration/common/mock_backend.go
@@ -57,7 +57,12 @@ type MockBackend struct {
 	// request to determine the response status and body.
 	ResponseFunc func(r *http.Request, count int) (int, string)
 	// ResponseHeaders, if non-nil, is written to the response before the status code.
-	ResponseHeaders   map[string]string
+	ResponseHeaders map[string]string
+	// NoContentLength, if true, flushes the response headers before writing
+	// the body so the response uses chunked transfer encoding without a
+	// Content-Length header. The default (false) lets net/http infer a
+	// Content-Length for short bodies.
+	NoContentLength bool
 	// SSEEvents, if non-nil, switches the handler to server-sent event mode:
 	// each entry is written as one "data: <event>\n\n" frame followed by a
 	// flush. ResponseFunc/Response/Body are ignored in this mode.
@@ -67,7 +72,7 @@ type MockBackend struct {
 	SSEHold <-chan struct{}
 	// SSETrailing, if non-nil, is written (and flushed) after SSEHold is
 	// released, simulating backend data arriving after a client abort.
-	SSETrailing []string
+	SSETrailing       []string
 	hits              int
 	mu                sync.Mutex
 	models            []string
@@ -160,6 +165,11 @@ func NewMockBackend(clusterName string, response int, body string) *MockBackend 
 			w.Header().Set(k, v)
 		}
 		w.WriteHeader(status)
+		if b.NoContentLength {
+			if flusher, ok := w.(http.Flusher); ok {
+				flusher.Flush()
+			}
+		}
 		if body != "" {
 			w.Write([]byte(body))
 		}

--- a/tests/integration/implementation/scenario-SC03-rmb-quota/sc03_rmb_quota_test.go
+++ b/tests/integration/implementation/scenario-SC03-rmb-quota/sc03_rmb_quota_test.go
@@ -55,11 +55,22 @@ var audioBody = []byte(`{"model":"gpt-audio-1.5"}`)
 var audioStreamBody = []byte(`{"model":"gpt-audio-1.5","stream":true}`)
 var imageGenerationBody = []byte(`{"model":"flux-2-pro","n":2}`)
 var highPrecisionBody = []byte(`{"model":"qwen2.5-omni-7b"}`)
+var anthropicBody = []byte(`{"model":"claude-sonnet-4-5"}`)
 
 var usageResponse = `{"usage":{"prompt_tokens":100,"completion_tokens":50,"total_tokens":150}}`
 var imageGenerationUsageResponse = `{"usage":{"image_count":2}}`
 
 // SSE format: final chunk contains usage. The trailing blank line is required.
+// anthropicUsageResponse is a complete Anthropic "message" response (note the
+// type:"message" field and input_tokens/output_tokens usage field names).
+// Together with anthropicBody and a Bearer (openai-style) API key it
+// reproduces the auth-style/response-format mismatch of issue #1364: the
+// token-auth module detects AuthStyle=openai from the request while the
+// backend actually speaks the Anthropic protocol.
+var anthropicUsageResponse = `{"id":"msg_01","type":"message","role":"assistant",` +
+	`"content":[{"type":"text","text":"hi"}],` +
+	`"usage":{"input_tokens":2000,"output_tokens":1500,"cache_read_input_tokens":8000}}`
+
 var streamUsageResponse = "data: {\"choices\":[{\"delta\":{\"role\":\"assistant\"}}]}\n\n" +
 	"data: {\"choices\":[{\"delta\":{\"content\":\"hello\"}}]}\n\n" +
 	"data: {\"usage\":{\"prompt_tokens\":100,\"completion_tokens\":50,\"total_tokens\":150}}\n\n"
@@ -330,6 +341,33 @@ func highPrecisionAIConf() *cluster_conf.AIConf {
 		Prices: cluster_conf.PriceMap{
 			"input_cost_per_token":  6.0168984e-09,
 			"output_cost_per_token": 7.6234102728e-08,
+		},
+	})
+	return conf
+}
+
+// anthropicAIConf adds an Anthropic-protocol model with cache pricing. The
+// round per-token prices (1e-6 / 2e-6 / 5e-7 / 1.5e-6 yuan) make the expected
+// fixed-point deduction easy to verify by hand:
+//
+//	cost = input*100 + cache_read*50 + output*200  (units of 1e-8 yuan)
+func anthropicAIConf() *cluster_conf.AIConf {
+	conf := defaultRMBAIConf()
+	conf.ModelTable.Models = append(conf.ModelTable.Models, cluster_conf.ModelPrice{
+		Provider:            "mock-provider",
+		Model:               "claude-sonnet-4-5",
+		BaseModel:           "claude-sonnet-4-5",
+		Mode:                "chat",
+		Capabilities:        []string{"chat"},
+		SupportedParameters: []string{"temperature", "max_tokens"},
+		Limits: map[string]interface{}{
+			"context_window": 128000,
+		},
+		Prices: cluster_conf.PriceMap{
+			"input_cost_per_token":            0.000001,
+			"output_cost_per_token":           0.000002,
+			"cache_read_input_token_cost":     0.0000005,
+			"cache_creation_input_token_cost": 0.0000015,
 		},
 	})
 	return conf
@@ -797,7 +835,6 @@ func TestTC12_RMBQuotaDeduction_ImageGeneration(t *testing.T) {
 	}
 }
 
-
 // TestTC13 verifies that a total_token quota plan with quota=0 can be loaded
 // and rejects requests with QuotaExhausted.
 func TestTC13_TokenQuotaZeroLoaded(t *testing.T) {
@@ -853,7 +890,6 @@ func TestTC14_TokenQuotaZeroMissingRedisKey(t *testing.T) {
 	}
 }
 
-
 // TestTC15 verifies end-to-end billing with prices that need more than 8
 // decimal places (scientific notation in cluster_conf.data). The prices
 // below come from the generated model catalog. With prompt=100 and
@@ -896,4 +932,73 @@ func TestTC15_RMBQuotaDeduction_HighPrecision(t *testing.T) {
 		e.logBFEAccess()
 		t.Fatalf("remaining quota = %d, want %d, response body: %s", remaining, want, body)
 	}
+}
+
+// anthropicMismatchRequest verifies the fixed-point deduction for an
+// Anthropic-protocol response received on an openai-style (Bearer key)
+// request, i.e. the issue #1364 shape. Prices are 1e-6 input / 2e-6 output /
+// 5e-7 cache_read yuan per token, i.e. 100 / 200 / 50 units per token.
+// Anthropic input_tokens excludes cached tokens, so billable normal input is
+// 2000 + 8000 - 8000 = 2000 and the total deduction is
+//
+//	2000*100 + 8000*50 + 1500*200 = 900000
+//
+// Before the fix, the unrecognized final usage was reduced to cache-read only
+// (400000 for the chunked framing, 0 for the Content-Length framing).
+func anthropicMismatchRequest(t *testing.T, noContentLength bool) {
+	aiConfs := map[string]*cluster_conf.AIConf{
+		clusterRMB: anthropicAIConf(),
+	}
+	e := newTestEnv(t, aiConfs, []common.QuotaPlan{rmbQuotaPlan(10000000000)})
+	defer e.Close()
+
+	e.redis.SetQuota(redisKeyRMB, 10000000000)
+
+	e.backends[clusterRMB].ResponseHeaders = map[string]string{"Content-Type": "application/json"}
+	e.backends[clusterRMB].NoContentLength = noContentLength
+	e.backends[clusterRMB].Body = anthropicUsageResponse
+
+	resp, body, err := e.sendRequest(apiHost, anthropicBody)
+	if err != nil {
+		t.Fatalf("send request failed: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		e.logBFEException()
+		t.Fatalf("expected status 200, got %d, body: %s", resp.StatusCode, body)
+	}
+
+	if e.backends[clusterRMB].Hits() != 1 {
+		t.Fatalf("expected 1 hit on %s, got %d", clusterRMB, e.backends[clusterRMB].Hits())
+	}
+
+	// Wait for async redis deduction.
+	time.Sleep(500 * time.Millisecond)
+	remaining := e.redis.GetQuota(redisKeyRMB)
+	want := int64(10000000000 - 900000)
+	if remaining != want {
+		e.logBFEException()
+		e.logBFEAccess()
+		t.Fatalf("remaining quota = %d, want %d (NoContentLength=%v), response body: %s",
+			remaining, want, noContentLength, body)
+	}
+}
+
+// TestTC16 verifies RMB quota deduction for a non-streaming Anthropic
+// response framed with chunked transfer encoding (no Content-Length). This
+// exercises the mod_body_process completion path: the final usage must be
+// recognized (type:"message") and marked, otherwise the request-finish guard
+// zeroes the billing fields and only cache-read would be deducted (issue
+// #1364).
+func TestTC16_RMBQuotaDeduction_Anthropic_NonStream_Chunked(t *testing.T) {
+	anthropicMismatchRequest(t, true)
+}
+
+// TestTC17 verifies RMB quota deduction for a non-streaming Anthropic
+// response with a Content-Length header. This exercises the
+// tokenReadResponseHandler path (res.ContentLength >= 0): the single
+// openai-style adapter parses nothing from the Anthropic body, so the
+// cross-protocol fallback must recover the usage (issue #1364). Before the
+// fix this deducted 0.
+func TestTC17_RMBQuotaDeduction_Anthropic_NonStream_ContentLength(t *testing.T) {
+	anthropicMismatchRequest(t, false)
 }

--- a/tests/integration/测试设计文档/scenario-SC03-RMB配额扣减/TC-16-Anthropic非流式chunked计费.md
+++ b/tests/integration/测试设计文档/scenario-SC03-RMB配额扣减/TC-16-Anthropic非流式chunked计费.md
@@ -1,0 +1,87 @@
+# TC-16 Anthropic 非流式 chunked 计费（跨协议回退，issue #1364）
+
+## 用例编号与名称
+
+TC-16 Anthropic 非流式 chunked 计费（Bearer 请求 + Anthropic 响应，chunked 传输）
+
+## 所属场景
+
+SC03 RMB 配额扣减
+
+## 版本声明
+
+- `bfe`：当前源码版本（含 issue #1364 修复）
+
+## 测试目的
+
+验证当请求以 openai 风格（`Bearer ak_user_a` + `/v1/chat/completions`）发出、后端实际返回
+Anthropic 协议 body（`type:"message"`、`input_tokens`/`output_tokens`），且响应以 chunked
+传输编码（无 `Content-Length`）时，BFE 仍能识别最终 usage 并按完整公式扣减 RMB 配额。
+
+修复前（issue #1364），该形态的最终 usage 不被识别为 final，请求结束守卫把计费字段清零时
+遗留了 `cache_read_input_tokens`，导致只按 cache-read 扣减（本用例为 400000），漏计
+input/output。
+
+## 运行模式
+
+单组件模式：仅启动真实 `bfe` 进程与嵌入式 Redis。
+
+## 前置条件
+
+1. 已编译 `bfe` 可执行文件。
+2. 嵌入式 Redis 已启动，并预置 `quota:plan_rmb = 10000000000`。
+3. mock 后端 `cluster_rmb` 已启动，返回 200、`Content-Type: application/json`，并通过先
+   flush 响应头的方式强制 chunked 传输编码（无 `Content-Length`），body 为：
+   ```json
+   {
+       "id": "msg_01",
+       "type": "message",
+       "role": "assistant",
+       "content": [{"type": "text", "text": "hi"}],
+       "usage": {
+           "input_tokens": 2000,
+           "output_tokens": 1500,
+           "cache_read_input_tokens": 8000
+       }
+   }
+   ```
+4. 临时 BFE 配置已加载，`cluster_rmb` 的 `ModelTable` 包含模型 `claude-sonnet-4-5`，价格：
+   - `input_cost_per_token`: `0.000001` → 定点整数 `100`
+   - `output_cost_per_token`: `0.000002` → 定点整数 `200`
+   - `cache_read_input_token_cost`: `0.0000005` → 定点整数 `50`
+   - `cache_creation_input_token_cost`: `0.0000015` → 定点整数 `150`
+5. `ak_user_a` 绑定 RMB 配额计划 `plan_rmb`。
+
+## 配置构造
+
+- `cluster_rmb.AIConf.ModelTable.Models` 增加模型 `claude-sonnet-4-5`（价格见前置条件 4）。
+- mock 后端 `NoContentLength = true`：响应头写出后立即 flush，使 body 以 chunked 编码传输。
+
+## BFE 请求
+
+发送 1 次 POST 请求：
+
+| 字段 | 值 |
+|------|-----|
+| Host | `rmb.example.org` |
+| Path | `/v1/chat/completions` |
+| Authorization | `Bearer ak_user_a` |
+| Body | `{"model":"claude-sonnet-4-5"}` |
+
+> 注意：请求是 openai 形态（Bearer key、`/v1/chat/completions`），响应是 Anthropic 形态，
+> 二者协议错配是本用例的核心设定。
+
+## 预期结果
+
+- 响应状态码：200。
+- `cluster_rmb` 收到 1 次命中（200）。
+- Redis 中 `quota:plan_rmb` 的余额按完整公式扣减：
+  - Anthropic 的 `input_tokens` 不含 cache 命中部分，故
+    normal_input = 2000 + 8000 - 8000 = 2000
+  - 扣减金额 = 2000 * 100 + 8000 * 50 + 1500 * 200 = 900000
+  - 剩余 = `10000000000 - 900000 = 99999100000`
+- 修复前本用例只扣 cache-read：8000 * 50 = 400000。
+
+## 清理
+
+停止 `bfe` 进程、mock 后端与嵌入式 Redis，删除临时目录。

--- a/tests/integration/测试设计文档/scenario-SC03-RMB配额扣减/TC-17-Anthropic非流式Content-Length计费.md
+++ b/tests/integration/测试设计文档/scenario-SC03-RMB配额扣减/TC-17-Anthropic非流式Content-Length计费.md
@@ -1,0 +1,86 @@
+# TC-17 Anthropic 非流式 Content-Length 计费（跨协议回退，issue #1364）
+
+## 用例编号与名称
+
+TC-17 Anthropic 非流式 Content-Length 计费（Bearer 请求 + Anthropic 响应，带 Content-Length）
+
+## 所属场景
+
+SC03 RMB 配额扣减
+
+## 版本声明
+
+- `bfe`：当前源码版本（含 issue #1364 修复）
+
+## 测试目的
+
+验证当请求以 openai 风格（`Bearer ak_user_a` + `/v1/chat/completions`）发出、后端实际返回
+Anthropic 协议 body（`type:"message"`、`input_tokens`/`output_tokens`），且响应带
+`Content-Length` 头时，BFE 在 `tokenReadResponseHandler` 路径上通过跨协议回退识别 usage，
+并按完整公式扣减 RMB 配额。
+
+修复前（issue #1364），该形态下 openai 单协议适配器解析不到任何字段，未做跨协议回退，
+最终扣减为 0（usage 被清零、也无估算补偿）。
+
+## 运行模式
+
+单组件模式：仅启动真实 `bfe` 进程与嵌入式 Redis。
+
+## 前置条件
+
+1. 已编译 `bfe` 可执行文件。
+2. 嵌入式 Redis 已启动，并预置 `quota:plan_rmb = 10000000000`。
+3. mock 后端 `cluster_rmb` 已启动，返回 200、`Content-Type: application/json`，body 为：
+   ```json
+   {
+       "id": "msg_01",
+       "type": "message",
+       "role": "assistant",
+       "content": [{"type": "text", "text": "hi"}],
+       "usage": {
+           "input_tokens": 2000,
+           "output_tokens": 1500,
+           "cache_read_input_tokens": 8000
+       }
+   }
+   ```
+   （Go net/http 会对短 body 自动补 `Content-Length`，无需额外设置。）
+4. 临时 BFE 配置已加载，`cluster_rmb` 的 `ModelTable` 包含模型 `claude-sonnet-4-5`，价格：
+   - `input_cost_per_token`: `0.000001` → 定点整数 `100`
+   - `output_cost_per_token`: `0.000002` → 定点整数 `200`
+   - `cache_read_input_token_cost`: `0.0000005` → 定点整数 `50`
+   - `cache_creation_input_token_cost`: `0.0000015` → 定点整数 `150`
+5. `ak_user_a` 绑定 RMB 配额计划 `plan_rmb`。
+
+## 配置构造
+
+- `cluster_rmb.AIConf.ModelTable.Models` 增加模型 `claude-sonnet-4-5`（价格见前置条件 4）。
+
+## BFE 请求
+
+发送 1 次 POST 请求：
+
+| 字段 | 值 |
+|------|-----|
+| Host | `rmb.example.org` |
+| Path | `/v1/chat/completions` |
+| Authorization | `Bearer ak_user_a` |
+| Body | `{"model":"claude-sonnet-4-5"}` |
+
+> 注意：请求是 openai 形态（Bearer key、`/v1/chat/completions`），响应是 Anthropic 形态，
+> 二者协议错配是本用例的核心设定。
+
+## 预期结果
+
+- 响应状态码：200。
+- `cluster_rmb` 收到 1 次命中（200）。
+- Redis 中 `quota:plan_rmb` 的余额按完整公式扣减：
+  - Anthropic 的 `input_tokens` 不含 cache 命中部分，故
+    normal_input = 2000 + 8000 - 8000 = 2000
+  - 扣减金额 = 2000 * 100 + 8000 * 50 + 1500 * 200 = 900000
+  - 剩余 = `10000000000 - 900000 = 99999100000`
+- 修复前本用例扣减为 0。
+
+## 清理
+
+停止 `bfe` 进程、mock 后端与嵌入式 Redis，删除临时目录。

--- a/tests/integration/测试设计文档/scenario-SC03-RMB配额扣减/场景说明.md
+++ b/tests/integration/测试设计文档/scenario-SC03-RMB配额扣减/场景说明.md
@@ -16,7 +16,8 @@ BFE v0.4 在 `mod_ai_token_auth` 中引入 RMB（人民币）配额支持。与 
 - 含音频的模型按音频 input/output 拆分公式计费（非流式与流式）；
 - 图像生成模型按实际生成张数 `image_count` 与 `output_cost_per_image` 计费（非流式）；
 - `total_token` 配额计划 `Quota=0` 的配置可以正常加载，且请求被 429 拒绝（回归 ai-gateway-api#136）；
-- `Quota=0` 且 Redis 余额 key 未初始化时，同样返回 429 配额耗尽而非 500 内部错误。
+- `Quota=0` 且 Redis 余额 key 未初始化时，同样返回 429 配额耗尽而非 500 内部错误；
+- openai 风格请求（Bearer key）收到 Anthropic 协议响应（`type:"message"`，与请求协议错配）时，无论响应是 chunked 传输还是带 `Content-Length`，都能识别最终 usage 并按完整公式扣减（回归 issue #1364，TC-16/TC-17）。
 
 > 注：TC-12 编号跳过 TC-11，是为了与后续可能补充的流式图像生成测试例预留空间。
 
@@ -255,6 +256,9 @@ BFE v0.4 在 `mod_ai_token_auth` 中引入 RMB（人民币）配额支持。与 
 | TC-12 | ImageGeneration 模型按次计费 | 请求 `/v1/images/generations`，后端返回 `usage.image_count = 2`，按 `2 * 0.03` 元扣减 |
 | TC-13 | total_token 配额为 0 可加载并拒绝请求 | `Quota=0` 的 `total_token` 计划可正常加载启动，请求返回 429 配额耗尽 |
 | TC-14 | total_token 配额为 0 且 RedisKey 未初始化时拒绝请求 | `Quota=0` 且 Redis key 不存在时返回 429 配额耗尽而非 500 内部错误 |
+| TC-15 | 高精度价格计费 | 超过 8 位小数（科学计数法）的价格按定点整数正确扣减 |
+| TC-16 | Anthropic 非流式 chunked 计费 | Bearer 请求收到 Anthropic 响应（chunked 传输），最终 usage 被识别并按完整公式扣减 900000（修复前只扣 cache-read 400000） |
+| TC-17 | Anthropic 非流式 Content-Length 计费 | 同上但响应带 `Content-Length`，走 `tokenReadResponseHandler` 跨协议回退路径扣减 900000（修复前扣 0） |
 
 ## 7. 公共基础设施改造
 
@@ -267,7 +271,8 @@ BFE v0.4 在 `mod_ai_token_auth` 中引入 RMB（人民币）配额支持。与 
    - 基于 `github.com/alicebob/miniredis/v2` 启动嵌入式 Redis；
    - 提供 `SetQuota` / `GetQuota` 辅助方法，用于预置余额和断言扣减结果。
 3. **`common/mock_backend.go`**：
-   - 支持返回带 `usage` 字段的响应体（`prompt_tokens`、`completion_tokens`、`total_tokens`）。
+   - 支持返回带 `usage` 字段的响应体（`prompt_tokens`、`completion_tokens`、`total_tokens`）；
+   - 支持 `NoContentLength`：写出响应头后先 flush，强制 chunked 传输编码（无 `Content-Length`），用于覆盖非流式响应的两种传输帧形态。
 
 ## 8. 依赖与风险
 


### PR DESCRIPTION


Fixes #1364. When a Bearer (openai-style) request is answered with an Anthropic body (type:"message", input_tokens/output_tokens), the final usage was not recognized and the request-finish guard zeroed the billing fields, leaving only cache_read to be deducted (chunked framing) or nothing at all (Content-Length framing).

- guard in tokenRequestFinishHandler now clears all 10 billing fields (prompt/completion/total/quota/cache/audio/image/video) instead of UsedQuota alone
- UpdateCtxByUsage falls back to the composed cross-protocol parse chain (ParseUsageFieldsCrossProtocol) when the single auth-style adapter yields all-zero prompt/completion
- isFinalUsage accepts a top-level type:"message" marker; RawEvent marks IsFinalUsage/IsTermination for a complete non-SSE JSON body
- SC03 integration tests: TestTC16 (chunked) / TestTC17 (Content-Length), mock backend gains NoContentLength switch